### PR TITLE
test(DR-575): unit tests for VR fallback components

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "test:integration:kafka:gdpr": "jest --config=./integration/kafka/jest.config.kafka.js --testPathPattern=\"gdpr-events\"",
     "test:e2e:gdpr": "cypress run --spec tests/e2e/web-client/gdpr-compliance.cy.js",
     "test:e2e:gdpr:open": "cypress open --spec tests/e2e/web-client/gdpr-compliance.cy.js",
+    "test:dr575": "jest --config=tests/DR-575-vr-fallback/jest.config.js --verbose",
+    "test:dr575:unit": "jest --config=tests/DR-575-vr-fallback/jest.config.js --testPathPattern=unit --verbose",
     "test:all": "npm run test && npm run test:performance && npm run test:security && npm run test:accessibility",
     "setup": "node tools/setup/environment.js",
     "mock:start": "node mocks/services/mock-server.js",
@@ -80,6 +82,7 @@
   "devDependencies": {
     "@babel/core": "^7.28.4",
     "@babel/preset-env": "^7.28.3",
+    "@babel/preset-react": "^7.28.5",
     "@dreamscape/db": "file:../dreamscape-services/db",
     "@faker-js/faker": "^10.0.0",
     "@playwright/test": "^1.55.0",
@@ -96,6 +99,7 @@
     "babel-jest": "^30.1.2",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "jest-environment-jsdom": "^30.2.0",
     "jsonwebtoken": "^9.0.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/tests/DR-575-vr-fallback/jest.config.js
+++ b/tests/DR-575-vr-fallback/jest.config.js
@@ -1,0 +1,35 @@
+/**
+ * Jest config for DR-575 VR Fallback tests
+ * Uses jsdom environment and transforms panorama source files with JSX support
+ */
+const path = require('path');
+
+module.exports = {
+  testEnvironment: 'jsdom',
+  rootDir: '../..',
+  testMatch: [
+    '<rootDir>/tests/DR-575-vr-fallback/**/*.test.js',
+  ],
+  transform: {
+    '^.+\\.jsx?$': ['babel-jest', {
+      presets: [
+        ['@babel/preset-env', { targets: { node: 'current' } }],
+        ['@babel/preset-react', { runtime: 'automatic' }],
+      ],
+    }],
+  },
+  transformIgnorePatterns: [
+    '/node_modules/',
+  ],
+  // Force all imports of 'react' and 'react-dom' to use dreamscape-tests' versions
+  // This avoids dual React instance issues when importing panorama components
+  moduleNameMapper: {
+    '^react$': path.resolve(__dirname, '../../node_modules/react'),
+    '^react/(.*)$': path.resolve(__dirname, '../../node_modules/react/$1'),
+    '^react-dom$': path.resolve(__dirname, '../../node_modules/react-dom'),
+    '^react-dom/(.*)$': path.resolve(__dirname, '../../node_modules/react-dom/$1'),
+  },
+  moduleFileExtensions: ['js', 'jsx', 'json'],
+  verbose: true,
+  testTimeout: 15000,
+};

--- a/tests/DR-575-vr-fallback/unit/PanoramaGallery.test.js
+++ b/tests/DR-575-vr-fallback/unit/PanoramaGallery.test.js
@@ -1,0 +1,199 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * PanoramaGallery Component Tests
+ * DR-575: 2D Gallery Mode
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PanoramaGallery from '../../../../dreamscape-frontend/panorama/src/components/PanoramaGallery';
+
+// Mock the environments module
+jest.mock('../../../../dreamscape-frontend/panorama/src/data/environments', () => ({
+  listVREnvironments: () => [
+    { id: 'paris', name: 'Paris', description: 'Ville Lumière', sceneCount: 3, defaultScene: 'eiffel-tower' },
+    { id: 'barcelona', name: 'Barcelona', description: 'Ville Catalane', sceneCount: 2, defaultScene: 'sagrada' },
+  ],
+  VR_ENVIRONMENTS: {
+    paris: {
+      name: 'Paris',
+      description: 'Ville Lumière',
+      scenes: [
+        { id: 'eiffel-tower', name: 'Tour Eiffel', description: 'Vue du Champ de Mars', icon: '🗼', panoramaUrl: '/paris/eiffel.jpg', thumbnailUrl: '/paris/thumb-eiffel.jpg' },
+        { id: 'louvre', name: 'Musée du Louvre', description: 'La pyramide', icon: '🏛️', panoramaUrl: '/paris/louvre.jpg', thumbnailUrl: '/paris/thumb-louvre.jpg' },
+        { id: 'sacre-coeur', name: 'Sacré-Cœur', description: 'Montmartre', icon: '⛪', panoramaUrl: '/paris/sacre-coeur.jpg', thumbnailUrl: '/paris/thumb-sacre.jpg' },
+      ],
+    },
+    barcelona: {
+      name: 'Barcelona',
+      description: 'Ville Catalane',
+      scenes: [
+        { id: 'sagrada', name: 'Sagrada Família', description: 'Basilique de Gaudí', icon: '⛪', panoramaUrl: '/bcn/sagrada.jpg', thumbnailUrl: '/bcn/thumb-sagrada.jpg' },
+        { id: 'park-guell', name: 'Park Güell', description: 'Parc de Gaudí', icon: '🏞️', panoramaUrl: '/bcn/guell.jpg', thumbnailUrl: '/bcn/thumb-guell.jpg' },
+      ],
+    },
+  },
+}));
+
+describe('PanoramaGallery (DR-575)', () => {
+  const defaultProps = {
+    onSwitchToVR: jest.fn(),
+    onSwitchTo3D: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the gallery header', () => {
+    render(<PanoramaGallery {...defaultProps} />);
+
+    expect(screen.getByText('DreamScape')).toBeInTheDocument();
+    expect(screen.getByText('Explorez nos destinations')).toBeInTheDocument();
+  });
+
+  it('displays all destinations in the grid', () => {
+    render(<PanoramaGallery {...defaultProps} />);
+
+    expect(screen.getByText('Paris')).toBeInTheDocument();
+    expect(screen.getByText('Barcelona')).toBeInTheDocument();
+  });
+
+  it('shows scene count badges', () => {
+    render(<PanoramaGallery {...defaultProps} />);
+
+    expect(screen.getByText('3 panoramas')).toBeInTheDocument();
+    expect(screen.getByText('2 panoramas')).toBeInTheDocument();
+  });
+
+  it('opens panorama viewer when a destination card is clicked', () => {
+    render(<PanoramaGallery {...defaultProps} />);
+
+    fireEvent.click(screen.getByLabelText('Explorer Paris'));
+
+    // Scene name appears in overlay + thumbnail strip, so use getAllByText
+    expect(screen.getAllByText(/Tour Eiffel/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('1 / 3')).toBeInTheDocument();
+  });
+
+  it('navigates to next scene', () => {
+    render(<PanoramaGallery {...defaultProps} />);
+
+    fireEvent.click(screen.getByLabelText('Explorer Paris'));
+    fireEvent.click(screen.getByLabelText('Scène suivante'));
+
+    expect(screen.getByText('2 / 3')).toBeInTheDocument();
+  });
+
+  it('navigates to previous scene', () => {
+    render(<PanoramaGallery {...defaultProps} />);
+
+    fireEvent.click(screen.getByLabelText('Explorer Paris'));
+    // Go to last scene (wraps around)
+    fireEvent.click(screen.getByLabelText('Scène précédente'));
+
+    expect(screen.getByText('3 / 3')).toBeInTheDocument();
+  });
+
+  it('returns to grid when back button is clicked', () => {
+    render(<PanoramaGallery {...defaultProps} />);
+
+    fireEvent.click(screen.getByLabelText('Explorer Paris'));
+    expect(screen.getByText('1 / 3')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Retour aux destinations'));
+
+    // Back to grid
+    expect(screen.getByText('Explorez nos destinations')).toBeInTheDocument();
+  });
+
+  it('calls onSwitchToVR when VR button is clicked', () => {
+    const onSwitchToVR = jest.fn();
+    render(<PanoramaGallery {...defaultProps} onSwitchToVR={onSwitchToVR} />);
+
+    fireEvent.click(screen.getByLabelText('Retour en mode VR'));
+
+    expect(onSwitchToVR).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onSwitchTo3D when 3D button is clicked', () => {
+    const onSwitchTo3D = jest.fn();
+    render(<PanoramaGallery {...defaultProps} onSwitchTo3D={onSwitchTo3D} />);
+
+    fireEvent.click(screen.getByLabelText('Mode 3D interactif'));
+
+    expect(onSwitchTo3D).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports keyboard navigation (ArrowRight)', () => {
+    render(<PanoramaGallery {...defaultProps} />);
+
+    fireEvent.click(screen.getByLabelText('Explorer Paris'));
+    expect(screen.getByText('1 / 3')).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    expect(screen.getByText('2 / 3')).toBeInTheDocument();
+  });
+
+  it('supports keyboard navigation (ArrowLeft)', () => {
+    render(<PanoramaGallery {...defaultProps} />);
+
+    fireEvent.click(screen.getByLabelText('Explorer Paris'));
+    expect(screen.getByText('1 / 3')).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+    expect(screen.getByText('3 / 3')).toBeInTheDocument();
+  });
+
+  it('supports Escape key to return to grid', () => {
+    render(<PanoramaGallery {...defaultProps} />);
+
+    fireEvent.click(screen.getByLabelText('Explorer Paris'));
+    expect(screen.getByText('1 / 3')).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.getByText('Explorez nos destinations')).toBeInTheDocument();
+  });
+
+  // === Tests avec destination fixée (mode ?destination=paris) ===
+
+  it('starts directly on scenes when destination prop is provided', () => {
+    render(<PanoramaGallery {...defaultProps} destination="paris" />);
+
+    // Should show Paris scenes directly, not the grid
+    expect(screen.getAllByText(/Tour Eiffel/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('1 / 3')).toBeInTheDocument();
+    // Grid title should NOT be visible
+    expect(screen.queryByText('Explorez nos destinations')).not.toBeInTheDocument();
+  });
+
+  it('does not show back button when destination is locked', () => {
+    render(<PanoramaGallery {...defaultProps} destination="paris" />);
+
+    expect(screen.queryByLabelText('Retour aux destinations')).not.toBeInTheDocument();
+  });
+
+  it('Escape does not return to grid when destination is locked', () => {
+    render(<PanoramaGallery {...defaultProps} destination="paris" />);
+
+    expect(screen.getAllByText(/Tour Eiffel/).length).toBeGreaterThanOrEqual(1);
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    // Should still show the scene, not the grid
+    expect(screen.getAllByText(/Tour Eiffel/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText('Explorez nos destinations')).not.toBeInTheDocument();
+  });
+
+  it('navigates between scenes with locked destination', () => {
+    render(<PanoramaGallery {...defaultProps} destination="paris" />);
+
+    expect(screen.getByText('1 / 3')).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Scène suivante'));
+    expect(screen.getByText('2 / 3')).toBeInTheDocument();
+  });
+});

--- a/tests/DR-575-vr-fallback/unit/VRUnavailableScreen.test.js
+++ b/tests/DR-575-vr-fallback/unit/VRUnavailableScreen.test.js
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * VRUnavailableScreen Component Tests
+ * DR-575: VR Fallback Screen
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import VRUnavailableScreen from '../../../../dreamscape-frontend/panorama/src/components/VRUnavailableScreen';
+
+describe('VRUnavailableScreen (DR-575)', () => {
+  const defaultProps = {
+    xrReason: 'no-webxr-api',
+    onSwitchToGallery: jest.fn(),
+    onSwitchTo3D: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('displays correct message for no-webxr-api', () => {
+    render(<VRUnavailableScreen {...defaultProps} xrReason="no-webxr-api" />);
+
+    expect(screen.getByText('Navigateur non compatible WebXR')).toBeInTheDocument();
+    expect(screen.getByText(/ne supporte pas la réalité virtuelle/)).toBeInTheDocument();
+  });
+
+  it('displays correct message for no-headset', () => {
+    render(<VRUnavailableScreen {...defaultProps} xrReason="no-headset" />);
+
+    expect(screen.getByText('Casque VR non détecté')).toBeInTheDocument();
+    expect(screen.getByText(/Aucun casque de réalité virtuelle/)).toBeInTheDocument();
+  });
+
+  it('displays correct message for error', () => {
+    render(<VRUnavailableScreen {...defaultProps} xrReason="error" />);
+
+    expect(screen.getByText('Erreur de détection VR')).toBeInTheDocument();
+    expect(screen.getByText(/erreur est survenue/)).toBeInTheDocument();
+  });
+
+  it('calls onSwitchToGallery when gallery button is clicked', () => {
+    const onSwitchToGallery = jest.fn();
+    render(<VRUnavailableScreen {...defaultProps} onSwitchToGallery={onSwitchToGallery} />);
+
+    fireEvent.click(screen.getByLabelText('Explorer en mode Galerie 2D'));
+
+    expect(onSwitchToGallery).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onSwitchTo3D when 3D button is clicked', () => {
+    const onSwitchTo3D = jest.fn();
+    render(<VRUnavailableScreen {...defaultProps} onSwitchTo3D={onSwitchTo3D} />);
+
+    fireEvent.click(screen.getByLabelText('Voir en mode 3D interactif'));
+
+    expect(onSwitchTo3D).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the DreamScape logo', () => {
+    render(<VRUnavailableScreen {...defaultProps} />);
+
+    expect(screen.getByText('DreamScape')).toBeInTheDocument();
+  });
+
+  it('renders help section', () => {
+    render(<VRUnavailableScreen {...defaultProps} />);
+
+    expect(screen.getByText('Comment activer la VR ?')).toBeInTheDocument();
+  });
+
+  it('has accessible button labels', () => {
+    render(<VRUnavailableScreen {...defaultProps} />);
+
+    expect(screen.getByLabelText('Explorer en mode Galerie 2D')).toBeInTheDocument();
+    expect(screen.getByLabelText('Voir en mode 3D interactif')).toBeInTheDocument();
+  });
+});

--- a/tests/DR-575-vr-fallback/unit/useWebXRDetection.test.js
+++ b/tests/DR-575-vr-fallback/unit/useWebXRDetection.test.js
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * useWebXRDetection Hook Tests
+ * DR-575: WebXR Detection & Fallback
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import useWebXRDetection from '../../../../dreamscape-frontend/panorama/src/hooks/useWebXRDetection';
+
+// Save original navigator.xr
+const originalXR = navigator.xr;
+
+afterEach(() => {
+  // Restore navigator.xr
+  Object.defineProperty(navigator, 'xr', {
+    value: originalXR,
+    writable: true,
+    configurable: true,
+  });
+});
+
+describe('useWebXRDetection (DR-575)', () => {
+  it('starts with isChecking=true', () => {
+    Object.defineProperty(navigator, 'xr', {
+      value: { isSessionSupported: jest.fn(() => new Promise(() => {})) },
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useWebXRDetection());
+
+    expect(result.current.isChecking).toBe(true);
+  });
+
+  it('returns no-webxr-api when navigator.xr is missing', async () => {
+    Object.defineProperty(navigator, 'xr', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useWebXRDetection());
+
+    await waitFor(() => {
+      expect(result.current.isChecking).toBe(false);
+    });
+
+    expect(result.current.isXRSupported).toBe(false);
+    expect(result.current.xrReason).toBe('no-webxr-api');
+  });
+
+  it('returns supported when immersive-vr is available', async () => {
+    Object.defineProperty(navigator, 'xr', {
+      value: { isSessionSupported: jest.fn().mockResolvedValue(true) },
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useWebXRDetection());
+
+    await waitFor(() => {
+      expect(result.current.isChecking).toBe(false);
+    });
+
+    expect(result.current.isXRSupported).toBe(true);
+    expect(result.current.xrReason).toBe('supported');
+  });
+
+  it('returns no-headset when immersive-vr is not supported', async () => {
+    Object.defineProperty(navigator, 'xr', {
+      value: { isSessionSupported: jest.fn().mockResolvedValue(false) },
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useWebXRDetection());
+
+    await waitFor(() => {
+      expect(result.current.isChecking).toBe(false);
+    });
+
+    expect(result.current.isXRSupported).toBe(false);
+    expect(result.current.xrReason).toBe('no-headset');
+  });
+
+  it('returns error when isSessionSupported throws', async () => {
+    Object.defineProperty(navigator, 'xr', {
+      value: { isSessionSupported: jest.fn().mockRejectedValue(new Error('fail')) },
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useWebXRDetection());
+
+    await waitFor(() => {
+      expect(result.current.isChecking).toBe(false);
+    });
+
+    expect(result.current.isXRSupported).toBe(false);
+    expect(result.current.xrReason).toBe('error');
+  });
+
+  it('sets isChecking=false after detection completes', async () => {
+    Object.defineProperty(navigator, 'xr', {
+      value: { isSessionSupported: jest.fn().mockResolvedValue(true) },
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useWebXRDetection());
+
+    // Initially checking
+    expect(result.current.isChecking).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isChecking).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 6 tests for `useWebXRDetection` hook (WebXR API mock scenarios)
- 8 tests for `VRUnavailableScreen` (contextual messages, callbacks, accessibility)
- 16 tests for `PanoramaGallery` (grid rendering, viewer navigation, keyboard nav, locked destination mode)
- Dedicated `jest.config.js` with jsdom env, Babel JSX transform, and cross-repo React aliasing
- 30/30 tests passing

## Test plan
- [ ] Run `npx jest --config=tests/DR-575-vr-fallback/jest.config.js` → 30/30 pass
- [ ] No tests in `dreamscape-frontend` — all centralized here

🤖 Generated with [Claude Code](https://claude.com/claude-code)