### PR TITLE
feat(tests): unit tests DR-542 to DR-545 — user-service (257 tests, 98.73% coverage)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,7 +31,16 @@ module.exports = {
     '^@dreamscape/db$': '<rootDir>/../dreamscape-services/db/index.ts',
     '^@dreamscape/kafka$': '<rootDir>/../dreamscape-services/shared/kafka/src/index.ts',
     '^@/(.*)$': '<rootDir>/../dreamscape-services/voyage/src/$1',
-    '^@ai/(.*)$': '<rootDir>/../dreamscape-services/ai/src/$1'
+    '^@ai/(.*)$': '<rootDir>/../dreamscape-services/ai/src/$1',
+    // User-service internal aliases
+    '^@controllers/(.*)$': '<rootDir>/../dreamscape-services/user/src/controllers/$1',
+    '^@services/(.*)$': '<rootDir>/../dreamscape-services/user/src/services/$1',
+    '^@middleware/(.*)$': '<rootDir>/../dreamscape-services/user/src/middleware/$1',
+    '^@routes/(.*)$': '<rootDir>/../dreamscape-services/user/src/routes/$1',
+    '^@types/(.*)$': '<rootDir>/../dreamscape-services/user/src/types/$1',
+    '^@types_onboarding$': '<rootDir>/../dreamscape-services/user/src/types/onboarding.ts',
+    // Canonical resolution so jest.mock('express-rate-limit') intercepts the same module instance
+    '^express-rate-limit$': '<rootDir>/../dreamscape-services/user/node_modules/express-rate-limit'
   },
 
   // Timeout for tests
@@ -53,7 +62,13 @@ module.exports = {
           '@/*': ['../dreamscape-services/voyage/src/*'],
           '@ai/*': ['../dreamscape-services/ai/src/*'],
           '@dreamscape/db': ['../dreamscape-services/db/index.ts'],
-          '@dreamscape/kafka': ['../dreamscape-services/shared/kafka/src/index.ts']
+          '@dreamscape/kafka': ['../dreamscape-services/shared/kafka/src/index.ts'],
+          '@controllers/*': ['../dreamscape-services/user/src/controllers/*'],
+          '@services/*': ['../dreamscape-services/user/src/services/*'],
+          '@middleware/*': ['../dreamscape-services/user/src/middleware/*'],
+          '@routes/*': ['../dreamscape-services/user/src/routes/*'],
+          '@types/*': ['../dreamscape-services/user/src/types/*'],
+          '@types_onboarding': ['../dreamscape-services/user/src/types/onboarding.ts']
         }
       }
     }],

--- a/tests/DR-542-user-controllers/unit/aiIntegration.controller.test.ts
+++ b/tests/DR-542-user-controllers/unit/aiIntegration.controller.test.ts
@@ -1,0 +1,378 @@
+import request from 'supertest';
+import express, { Express } from 'express';
+import { jest, describe, it, expect, beforeAll, beforeEach, afterEach } from '@jest/globals';
+
+// Mock Prisma — no auth needed for these internal endpoints
+const mockUserFindUnique = jest.fn();
+const mockUserFindMany = jest.fn();
+const mockUserCount = jest.fn();
+const mockTravelOnboardingProfileCount = jest.fn();
+const mockAnalyticsCreate = jest.fn();
+const mockAnalyticsCount = jest.fn();
+
+jest.mock('@dreamscape/db', () => ({
+  prisma: {
+    user: {
+      findUnique: mockUserFindUnique,
+      findMany: mockUserFindMany,
+      count: mockUserCount,
+    },
+    travelOnboardingProfile: {
+      count: mockTravelOnboardingProfileCount,
+    },
+    analytics: {
+      create: mockAnalyticsCreate,
+      count: mockAnalyticsCount,
+    },
+  },
+}));
+
+import aiIntegrationRouter from '../../../../dreamscape-services/user/src/routes/aiIntegration';
+
+const userId = 'user-123';
+
+const mockUser = {
+  id: userId,
+  email: 'test@example.com',
+  onboardingCompleted: true,
+  onboardingCompletedAt: new Date(),
+  updatedAt: new Date(),
+  travelOnboarding: {
+    id: 'profile-1',
+    userId,
+    isCompleted: true,
+    completedSteps: ['destinations', 'budget', 'travel_types'],
+    version: 1,
+    travelTypes: ['ADVENTURE', 'CULTURAL'],
+    accommodationTypes: ['HOTEL'],
+    preferredDestinations: { regions: ['Europe'], countries: ['France'], climates: ['temperate'] },
+    globalBudgetRange: { min: 500, max: 2000, currency: 'EUR' },
+    budgetByCategory: null,
+    travelStyle: 'PLANNED',
+    comfortLevel: null,
+    accommodationLevel: 'STANDARD',
+    activityLevel: 'MODERATE',
+    riskTolerance: 'MODERATE',
+    budgetFlexibility: 'FLEXIBLE',
+    dateFlexibility: 'FLEXIBLE',
+    travelGroupTypes: [],
+    travelWithChildren: false,
+    childrenAges: [],
+    preferredSeasons: ['SPRING'],
+    weatherTolerances: null,
+    preferredTripDuration: null,
+    roomPreferences: null,
+    groupSize: null,
+    loyaltyPrograms: null,
+    paymentPreferences: [],
+    preferredAirlines: [],
+    cabinClassPreference: null,
+    transportModes: [],
+    transportBudgetShare: null,
+    activityTypes: ['hiking'],
+    interestCategories: ['culture'],
+    dietaryRequirements: [],
+    accessibilityNeeds: [],
+    healthConsiderations: [],
+    culturalConsiderations: [],
+    languageBarriers: [],
+    experienceLevel: null,
+    culturalImmersion: null,
+    climatePreferences: [],
+    travelPurposes: [],
+    serviceLevel: null,
+    privacyPreference: null,
+    updatedAt: new Date(),
+  },
+  settings: null,
+  preferences: null,
+};
+
+describe('AI Integration Controller', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/v1/ai', aiIntegrationRouter);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAnalyticsCreate.mockResolvedValue({} as never);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // ─── getUserPreferencesForAI ─────────────────────────────────────────────────
+  describe('GET /api/v1/ai/users/:userId/preferences', () => {
+    it('should return 400 when userId param is missing', async () => {
+      // Route requires a userId param — calling without it hits a different route
+      const res = await request(app)
+        .get('/api/v1/ai/users//preferences')
+        .expect(404); // express returns 404 for empty segment
+
+      // Confirm no data leak
+      expect(res.body.data).toBeUndefined();
+    });
+
+    it('should return 404 when user does not exist', async () => {
+      mockUserFindUnique.mockResolvedValue(null as never);
+
+      const res = await request(app)
+        .get(`/api/v1/ai/users/${userId}/preferences`)
+        .expect(404);
+
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toContain('not found');
+    });
+
+    it('should return 200 with AI-formatted preferences for a user with onboarding profile', async () => {
+      mockUserFindUnique.mockResolvedValue(mockUser as never);
+
+      const res = await request(app)
+        .get(`/api/v1/ai/users/${userId}/preferences`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.userId).toBe(userId);
+      expect(res.body.data.isOnboardingCompleted).toBe(true);
+      expect(res.body.data.preferences).toBeDefined();
+      expect(res.body.data.metadata).toBeDefined();
+    });
+
+    it('should return 200 with empty preferences when user has no onboarding profile', async () => {
+      mockUserFindUnique.mockResolvedValue({ ...mockUser, travelOnboarding: null } as never);
+
+      const res = await request(app)
+        .get(`/api/v1/ai/users/${userId}/preferences`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.preferences.destinations.regions).toEqual([]);
+      expect(res.body.data.preferences.travel.types).toEqual([]);
+    });
+
+    it('should include data quality metrics in metadata', async () => {
+      mockUserFindUnique.mockResolvedValue(mockUser as never);
+
+      const res = await request(app)
+        .get(`/api/v1/ai/users/${userId}/preferences`)
+        .expect(200);
+
+      expect(res.body.data.metadata.dataQuality.completeness).toBeGreaterThanOrEqual(0);
+      expect(res.body.data.metadata.dataQuality.completeness).toBeLessThanOrEqual(100);
+      expect(res.body.data.metadata.dataQuality.confidence).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should create an analytics event on success', async () => {
+      mockUserFindUnique.mockResolvedValue(mockUser as never);
+
+      await request(app).get(`/api/v1/ai/users/${userId}/preferences`).expect(200);
+
+      expect(mockAnalyticsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            event: 'ai_preferences_requested',
+            userId,
+          }),
+        })
+      );
+    });
+
+    it('should return 500 on internal error', async () => {
+      mockUserFindUnique.mockRejectedValue(new Error('DB error') as never);
+
+      const res = await request(app)
+        .get(`/api/v1/ai/users/${userId}/preferences`)
+        .expect(500);
+
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should map loyaltyPrograms when profile has loyalty entries', async () => {
+      const userWithLoyalty = {
+        ...mockUser,
+        travelOnboarding: {
+          ...mockUser.travelOnboarding,
+          loyaltyPrograms: [
+            { program: 'Air France Flying Blue', level: 'Gold', priority: 1 },
+            { program: 'Marriott Bonvoy', level: 'Platinum', priority: 2 },
+          ],
+        },
+      };
+      mockUserFindUnique.mockResolvedValue(userWithLoyalty as never);
+
+      const res = await request(app)
+        .get(`/api/v1/ai/users/${userId}/preferences`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.preferences.loyalty.programs).toHaveLength(2);
+      expect(res.body.data.preferences.loyalty.programs[0].program).toBe('Air France Flying Blue');
+    });
+  });
+
+  // ─── getBatchUserPreferencesForAI ────────────────────────────────────────────
+  describe('POST /api/v1/ai/users/preferences/batch', () => {
+    it('should return 400 when userIds is not an array', async () => {
+      const res = await request(app)
+        .post('/api/v1/ai/users/preferences/batch')
+        .send({ userIds: 'not-an-array' })
+        .expect(400);
+
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toContain('array');
+    });
+
+    it('should return 400 when userIds is empty array', async () => {
+      const res = await request(app)
+        .post('/api/v1/ai/users/preferences/batch')
+        .send({ userIds: [] })
+        .expect(400);
+
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should return 400 when more than 100 userIds are provided', async () => {
+      const userIds = Array.from({ length: 101 }, (_, i) => `user-${i}`);
+
+      const res = await request(app)
+        .post('/api/v1/ai/users/preferences/batch')
+        .send({ userIds })
+        .expect(400);
+
+      expect(res.body.error).toContain('Maximum 100');
+    });
+
+    it('should return 200 with batch preferences and meta', async () => {
+      mockUserFindMany.mockResolvedValue([mockUser] as never);
+
+      const res = await request(app)
+        .post('/api/v1/ai/users/preferences/batch')
+        .send({ userIds: [userId] })
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.users).toHaveLength(1);
+      expect(res.body.data.meta.requested).toBe(1);
+      expect(res.body.data.meta.found).toBe(1);
+      expect(res.body.data.meta.notFound).toHaveLength(0);
+    });
+
+    it('should correctly report notFound users in meta', async () => {
+      mockUserFindMany.mockResolvedValue([mockUser] as never);
+
+      const res = await request(app)
+        .post('/api/v1/ai/users/preferences/batch')
+        .send({ userIds: [userId, 'missing-user-id'] })
+        .expect(200);
+
+      expect(res.body.data.meta.requested).toBe(2);
+      expect(res.body.data.meta.found).toBe(1);
+      expect(res.body.data.meta.notFound).toContain('missing-user-id');
+    });
+
+    it('should return 500 on internal error', async () => {
+      mockUserFindMany.mockRejectedValue(new Error('DB error') as never);
+
+      const res = await request(app)
+        .post('/api/v1/ai/users/preferences/batch')
+        .send({ userIds: [userId] })
+        .expect(500);
+
+      expect(res.body.success).toBe(false);
+    });
+  });
+
+  // ─── getAIIntegrationHealth ──────────────────────────────────────────────────
+  describe('GET /api/v1/ai/health', () => {
+    beforeEach(() => {
+      mockUserCount
+        .mockResolvedValueOnce(100 as never)  // totalUsers
+        .mockResolvedValueOnce(60 as never);  // completedUsers
+      mockTravelOnboardingProfileCount
+        .mockResolvedValueOnce(80 as never)   // totalProfiles
+        .mockResolvedValueOnce(50 as never);  // completedProfiles
+      mockAnalyticsCount.mockResolvedValue(25 as never);
+    });
+
+    it('should return 200 with health data structure', async () => {
+      const res = await request(app)
+        .get('/api/v1/ai/health')
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.totalUsers).toBeDefined();
+      expect(res.body.data.onboardingStats).toBeDefined();
+      expect(res.body.data.aiIntegration).toBeDefined();
+      expect(res.body.data.healthStatus).toBeDefined();
+    });
+
+    it('should calculate completionRate correctly', async () => {
+      const res = await request(app)
+        .get('/api/v1/ai/health')
+        .expect(200);
+
+      // 60 completed / 100 total = 60%
+      expect(res.body.data.onboardingStats.completionRate).toBe(60);
+    });
+
+    it('should return healthStatus.overall as "healthy" when completedProfiles > 0', async () => {
+      const res = await request(app)
+        .get('/api/v1/ai/health')
+        .expect(200);
+
+      expect(res.body.data.healthStatus.overall).toBe('healthy');
+    });
+
+    it('should return healthStatus.overall as "warning" when completedProfiles is 0', async () => {
+      // Reset and re-mock with 0 completedProfiles
+      jest.resetAllMocks();
+      mockAnalyticsCreate.mockResolvedValue({} as never);
+      mockUserCount
+        .mockResolvedValueOnce(10 as never)
+        .mockResolvedValueOnce(0 as never);
+      mockTravelOnboardingProfileCount
+        .mockResolvedValueOnce(5 as never)
+        .mockResolvedValueOnce(0 as never); // completedProfiles = 0
+      mockAnalyticsCount.mockResolvedValue(0 as never);
+      mockAnalyticsCreate.mockResolvedValue({} as never);
+
+      const res = await request(app)
+        .get('/api/v1/ai/health')
+        .expect(200);
+
+      expect(res.body.data.healthStatus.overall).toBe('warning');
+    });
+
+    it('should safely handle 0 total users (avoid division by zero)', async () => {
+      jest.resetAllMocks();
+      mockAnalyticsCreate.mockResolvedValue({} as never);
+      mockUserCount.mockResolvedValue(0 as never);
+      mockTravelOnboardingProfileCount.mockResolvedValue(0 as never);
+      mockAnalyticsCount.mockResolvedValue(0 as never);
+      mockAnalyticsCreate.mockResolvedValue({} as never);
+
+      const res = await request(app)
+        .get('/api/v1/ai/health')
+        .expect(200);
+
+      expect(res.body.data.onboardingStats.completionRate).toBe(0);
+    });
+
+    it('should return 500 on internal error', async () => {
+      jest.resetAllMocks();
+      mockAnalyticsCreate.mockResolvedValue({} as never);
+      mockUserCount.mockRejectedValue(new Error('DB error') as never);
+
+      const res = await request(app)
+        .get('/api/v1/ai/health')
+        .expect(500);
+
+      expect(res.body.success).toBe(false);
+    });
+  });
+});

--- a/tests/DR-542-user-controllers/unit/onboarding.controller.test.ts
+++ b/tests/DR-542-user-controllers/unit/onboarding.controller.test.ts
@@ -1,0 +1,718 @@
+import request from 'supertest';
+import express, { Express } from 'express';
+import jwt from 'jsonwebtoken';
+import { jest, describe, it, expect, beforeAll, beforeEach, afterEach } from '@jest/globals';
+
+// Mock Prisma
+const mockTravelOnboardingProfileFindUnique = jest.fn();
+const mockTravelOnboardingProfileCreate = jest.fn();
+const mockTravelOnboardingProfileUpdate = jest.fn();
+const mockTravelOnboardingProfileDelete = jest.fn();
+const mockUserUpdate = jest.fn();
+const mockUserFindUnique = jest.fn();
+const mockAnalyticsCreate = jest.fn();
+const mockTokenBlacklistFindUnique = jest.fn();
+
+jest.mock('@dreamscape/db', () => ({
+  prisma: {
+    travelOnboardingProfile: {
+      findUnique: mockTravelOnboardingProfileFindUnique,
+      create: mockTravelOnboardingProfileCreate,
+      update: mockTravelOnboardingProfileUpdate,
+      delete: mockTravelOnboardingProfileDelete,
+    },
+    user: {
+      findUnique: mockUserFindUnique,
+      update: mockUserUpdate,
+    },
+    analytics: {
+      create: mockAnalyticsCreate,
+    },
+    tokenBlacklist: {
+      findUnique: mockTokenBlacklistFindUnique,
+    },
+  },
+}));
+
+import onboardingRouter from '../../../../dreamscape-services/user/src/routes/onboarding';
+
+const JWT_SECRET = 'test-jwt-secret-key-for-testing';
+const testUserId = 'test-user-id-123';
+const testUserEmail = 'test@example.com';
+
+const mockProfile = {
+  id: 'profile-1',
+  userId: testUserId,
+  isCompleted: false,
+  completedSteps: [],
+  version: 1,
+  preferredDestinations: null,
+  globalBudgetRange: null,
+  budgetByCategory: null,
+  preferredTripDuration: null,
+  roomPreferences: null,
+  groupSize: null,
+  weatherTolerances: null,
+  loyaltyPrograms: null,
+  travelTypes: [],
+  accommodationTypes: [],
+  completedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  user: {
+    onboardingCompleted: false,
+    onboardingCompletedAt: null,
+  },
+};
+
+describe('Onboarding Controller', () => {
+  let app: Express;
+  let validToken: string;
+
+  beforeAll(() => {
+    process.env.JWT_SECRET = JWT_SECRET;
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/v1/users/onboarding', onboardingRouter);
+  });
+
+  beforeEach(() => {
+    validToken = jwt.sign(
+      { userId: testUserId, email: testUserEmail, type: 'access' },
+      JWT_SECRET,
+      { expiresIn: '7d' }
+    );
+
+    jest.clearAllMocks();
+
+    // Default mocks for auth middleware
+    mockTokenBlacklistFindUnique.mockResolvedValue(null as never);
+    mockUserFindUnique.mockResolvedValue({
+      id: testUserId,
+      email: testUserEmail,
+      role: 'USER',
+    } as never);
+    mockAnalyticsCreate.mockResolvedValue({} as never);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // ─── getOnboardingProfile ───────────────────────────────────────────────────
+  describe('GET /api/v1/users/onboarding', () => {
+    it('should return 401 when no token is provided', async () => {
+      const res = await request(app)
+        .get('/api/v1/users/onboarding')
+        .expect(401);
+
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should return 404 when profile does not exist', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(null as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(404);
+
+      expect(res.body.error).toBeDefined();
+    });
+
+    it('should return 200 with profile when it exists', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(mockProfile as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toBeDefined();
+      expect(res.body.data.userId).toBe(testUserId);
+    });
+
+    it('should return 500 on internal error', async () => {
+      mockTravelOnboardingProfileFindUnique.mockRejectedValue(new Error('DB error') as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(500);
+
+      expect(res.body.error).toBeDefined();
+    });
+
+    it('should return 401 when auth middleware passes but user has no id', async () => {
+      // Auth middleware finds user but without id → req.user.id undefined
+      mockUserFindUnique.mockResolvedValue({ email: testUserEmail, role: 'USER' } as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(401);
+
+      expect(res.body.error).toBeDefined();
+    });
+  });
+
+  // ─── createOnboardingProfile ────────────────────────────────────────────────
+  describe('POST /api/v1/users/onboarding', () => {
+    it('should return 401 when no token is provided', async () => {
+      await request(app).post('/api/v1/users/onboarding').expect(401);
+    });
+
+    it('should return 201 when profile is successfully created', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(null as never);
+      mockTravelOnboardingProfileCreate.mockResolvedValue(mockProfile as never);
+
+      const res = await request(app)
+        .post('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.message).toContain('created');
+    });
+
+    it('should return 409 when profile already exists', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(mockProfile as never);
+
+      const res = await request(app)
+        .post('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(409);
+
+      expect(res.body.error).toBeDefined();
+    });
+
+    it('should return 409 on Prisma P2002 unique constraint error', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(null as never);
+      const p2002Err = Object.assign(new Error('Unique constraint'), { code: 'P2002' });
+      mockTravelOnboardingProfileCreate.mockRejectedValue(p2002Err as never);
+
+      const res = await request(app)
+        .post('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(409);
+
+      expect(res.body.error).toBeDefined();
+    });
+
+    it('should return 500 on internal error', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(null as never);
+      mockTravelOnboardingProfileCreate.mockRejectedValue(new Error('DB error') as never);
+
+      const res = await request(app)
+        .post('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(500);
+
+      expect(res.body.error).toBeDefined();
+    });
+
+    it('should return 401 when auth middleware passes but user has no id', async () => {
+      mockUserFindUnique.mockResolvedValue({ email: testUserEmail, role: 'USER' } as never);
+
+      const res = await request(app)
+        .post('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(401);
+
+      expect(res.body.error).toBeDefined();
+    });
+  });
+
+  // ─── updateOnboardingStep ───────────────────────────────────────────────────
+  describe('PUT /api/v1/users/onboarding/step', () => {
+    it('should return 401 when no token is provided', async () => {
+      await request(app).put('/api/v1/users/onboarding/step').send({ step: 'budget', data: {} }).expect(401);
+    });
+
+    it('should return 400 when step is missing', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({ data: {} })
+        .expect(400);
+
+      expect(res.body.error).toContain('Step is required');
+    });
+
+    it('should return 400 when data is missing', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({ step: 'budget' })
+        .expect(400);
+
+      expect(res.body.error).toContain('Step data is required');
+    });
+
+    it('should return 400 when budget globalBudgetRange has min >= max', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({
+          step: 'budget',
+          data: { globalBudgetRange: { min: 1000, max: 500, currency: 'EUR' } },
+        })
+        .expect(400);
+
+      expect(res.body.validationErrors).toBeDefined();
+    });
+
+    it('should return 400 when budget globalBudgetRange has no currency', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({
+          step: 'budget',
+          data: { globalBudgetRange: { min: 100, max: 500 } },
+        })
+        .expect(400);
+
+      expect(res.body.validationErrors).toBeDefined();
+    });
+
+    it('should return 400 when destinations regions is not an array', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({
+          step: 'destinations',
+          data: { preferredDestinations: { regions: 'not-an-array' } },
+        })
+        .expect(400);
+
+      expect(res.body.validationErrors).toBeDefined();
+    });
+
+    it('should return 400 when destinations countries is not an array', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({
+          step: 'destinations',
+          data: { preferredDestinations: { countries: 'France' } },
+        })
+        .expect(400);
+
+      expect(res.body.validationErrors).toBeDefined();
+    });
+
+    it('should return 400 when travel_types contains invalid values', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({
+          step: 'travel_types',
+          data: { travelTypes: ['INVALID_TYPE'] },
+        })
+        .expect(400);
+
+      expect(res.body.validationErrors).toBeDefined();
+    });
+
+    it('should return 400 when travel_types travelStyle is invalid', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({
+          step: 'travel_types',
+          data: { travelStyle: 'INVALID_STYLE' },
+        })
+        .expect(400);
+
+      expect(res.body.validationErrors).toBeDefined();
+    });
+
+    it('should return 400 when group_travel has children but no childrenAges', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({
+          step: 'group_travel',
+          data: { travelWithChildren: true },
+        })
+        .expect(400);
+
+      expect(res.body.validationErrors).toBeDefined();
+    });
+
+    it('should return 400 when comfort_service has invalid comfortLevel', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({
+          step: 'comfort_service',
+          data: { comfortLevel: 'ULTRA' },
+        })
+        .expect(400);
+
+      expect(res.body.validationErrors).toBeDefined();
+    });
+
+    it('should return 400 when timing has invalid dateFlexibility', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({
+          step: 'timing',
+          data: { dateFlexibility: 'VERY_RIGID' },
+        })
+        .expect(400);
+
+      expect(res.body.validationErrors).toBeDefined();
+    });
+
+    it('should return 400 when activities has invalid activityLevel', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({
+          step: 'activities',
+          data: { activityLevel: 'EXTREME' },
+        })
+        .expect(400);
+
+      expect(res.body.validationErrors).toBeDefined();
+    });
+
+    it('should return 400 when experience has invalid riskTolerance', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({
+          step: 'experience',
+          data: { riskTolerance: 'INSANE' },
+        })
+        .expect(400);
+
+      expect(res.body.validationErrors).toBeDefined();
+    });
+
+    it('should return 404 when profile does not exist', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(null as never);
+
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({
+          step: 'budget',
+          data: { globalBudgetRange: { min: 100, max: 500, currency: 'EUR' } },
+        })
+        .expect(404);
+
+      expect(res.body.error).toBeDefined();
+    });
+
+    it('should return 200 with updated profile and markCompleted=true', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(mockProfile as never);
+      const updatedProfile = { ...mockProfile, completedSteps: ['budget'] };
+      mockTravelOnboardingProfileUpdate.mockResolvedValue(updatedProfile as never);
+
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({
+          step: 'budget',
+          data: { globalBudgetRange: { min: 100, max: 500, currency: 'EUR' } },
+          markCompleted: true,
+        })
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.message).toContain('budget');
+    });
+
+    it('should return 500 on internal error', async () => {
+      mockTravelOnboardingProfileFindUnique.mockRejectedValue(new Error('DB error') as never);
+
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({ step: 'budget', data: { globalBudgetRange: { min: 100, max: 500, currency: 'EUR' } } })
+        .expect(500);
+
+      expect(res.body.error).toBeDefined();
+    });
+
+    it('should return 400 when budget globalBudgetRange has negative min', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({
+          step: 'budget',
+          data: { globalBudgetRange: { min: -100, max: 500, currency: 'EUR' } },
+        })
+        .expect(400);
+
+      expect(res.body.validationErrors).toBeDefined();
+    });
+
+    it('should return 400 when budget globalBudgetRange has negative max', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({
+          step: 'budget',
+          data: { globalBudgetRange: { min: 100, max: -500, currency: 'EUR' } },
+        })
+        .expect(400);
+
+      expect(res.body.validationErrors).toBeDefined();
+    });
+
+    it('should return 400 when destinations climates is not an array', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({
+          step: 'destinations',
+          data: { preferredDestinations: { climates: 'tropical' } },
+        })
+        .expect(400);
+
+      expect(res.body.validationErrors).toBeDefined();
+    });
+
+    it('should return 400 when travel_types travelTypes is not an array', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({
+          step: 'travel_types',
+          data: { travelTypes: 'ADVENTURE' },
+        })
+        .expect(400);
+
+      expect(res.body.validationErrors).toBeDefined();
+    });
+
+    it('should return 404 on Prisma P2025 when profile not found during update', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(mockProfile as never);
+      const p2025Err = Object.assign(new Error('Record not found'), { code: 'P2025' });
+      mockTravelOnboardingProfileUpdate.mockRejectedValue(p2025Err as never);
+
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({
+          step: 'budget',
+          data: { globalBudgetRange: { min: 100, max: 500, currency: 'EUR' } },
+          markCompleted: true,
+        })
+        .expect(404);
+
+      expect(res.body.error).toBeDefined();
+    });
+
+    it('should return 401 when auth middleware passes but user has no id', async () => {
+      mockUserFindUnique.mockResolvedValue({ email: testUserEmail, role: 'USER' } as never);
+
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({ step: 'budget', data: {} })
+        .expect(401);
+
+      expect(res.body.error).toBeDefined();
+    });
+  });
+
+  // ─── getOnboardingProgress ──────────────────────────────────────────────────
+  describe('GET /api/v1/users/onboarding/progress', () => {
+    it('should return 401 when no token is provided', async () => {
+      await request(app).get('/api/v1/users/onboarding/progress').expect(401);
+    });
+
+    it('should return 404 when profile does not exist', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(null as never);
+
+      await request(app)
+        .get('/api/v1/users/onboarding/progress')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(404);
+    });
+
+    it('should return correct progress percentage', async () => {
+      const profileWith2Steps = {
+        ...mockProfile,
+        completedSteps: ['destinations', 'budget'],
+      };
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(profileWith2Steps as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/onboarding/progress')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(200);
+
+      // 2 out of 13 steps = ~15%
+      expect(res.body.data.progressPercentage).toBe(Math.round((2 / 13) * 100));
+      expect(res.body.data.completedSteps).toHaveLength(2);
+    });
+
+    it('should return nextRecommendedStep as the first uncompleted step', async () => {
+      const profileWith1Step = {
+        ...mockProfile,
+        completedSteps: ['destinations'],
+      };
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(profileWith1Step as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/onboarding/progress')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(200);
+
+      expect(res.body.data.nextRecommendedStep).toBe('budget');
+    });
+
+    it('should return 500 on internal error', async () => {
+      mockTravelOnboardingProfileFindUnique.mockRejectedValue(new Error('DB error') as never);
+
+      await request(app)
+        .get('/api/v1/users/onboarding/progress')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(500);
+    });
+
+    it('should return 401 when auth middleware passes but user has no id', async () => {
+      mockUserFindUnique.mockResolvedValue({ email: testUserEmail, role: 'USER' } as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/onboarding/progress')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(401);
+
+      expect(res.body.error).toBeDefined();
+    });
+  });
+
+  // ─── completeOnboarding ─────────────────────────────────────────────────────
+  describe('POST /api/v1/users/onboarding/complete', () => {
+    it('should return 401 when no token is provided', async () => {
+      await request(app).post('/api/v1/users/onboarding/complete').expect(401);
+    });
+
+    it('should return 404 when profile does not exist', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(null as never);
+
+      await request(app)
+        .post('/api/v1/users/onboarding/complete')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(404);
+    });
+
+    it('should return 400 when required steps are missing', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue({
+        ...mockProfile,
+        completedSteps: ['destinations'], // missing budget, travel_types, accommodation, transport
+      } as never);
+
+      const res = await request(app)
+        .post('/api/v1/users/onboarding/complete')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(400);
+
+      expect(res.body.error).toContain('Missing required steps');
+    });
+
+    it('should return 200 when all required steps are completed', async () => {
+      const requiredSteps = ['destinations', 'budget', 'travel_types', 'accommodation', 'transport'];
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue({
+        ...mockProfile,
+        completedSteps: requiredSteps,
+      } as never);
+      mockTravelOnboardingProfileUpdate.mockResolvedValue({ ...mockProfile, isCompleted: true } as never);
+      mockUserUpdate.mockResolvedValue({ id: testUserId, onboardingCompleted: true, onboardingCompletedAt: new Date() } as never);
+
+      const res = await request(app)
+        .post('/api/v1/users/onboarding/complete')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.message).toContain('completed');
+    });
+
+    it('should return 500 on internal error', async () => {
+      mockTravelOnboardingProfileFindUnique.mockRejectedValue(new Error('DB error') as never);
+
+      await request(app)
+        .post('/api/v1/users/onboarding/complete')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(500);
+    });
+
+    it('should return 401 when auth middleware passes but user has no id', async () => {
+      mockUserFindUnique.mockResolvedValue({ email: testUserEmail, role: 'USER' } as never);
+
+      const res = await request(app)
+        .post('/api/v1/users/onboarding/complete')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(401);
+
+      expect(res.body.error).toBeDefined();
+    });
+  });
+
+  // ─── deleteOnboardingProfile ────────────────────────────────────────────────
+  describe('DELETE /api/v1/users/onboarding', () => {
+    it('should return 401 when no token is provided', async () => {
+      await request(app).delete('/api/v1/users/onboarding').expect(401);
+    });
+
+    it('should return 200 when profile is successfully deleted', async () => {
+      mockTravelOnboardingProfileDelete.mockResolvedValue(mockProfile as never);
+      mockUserUpdate.mockResolvedValue({ id: testUserId } as never);
+
+      const res = await request(app)
+        .delete('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.message).toContain('deleted');
+      expect(mockUserUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { onboardingCompleted: false, onboardingCompletedAt: null },
+        })
+      );
+    });
+
+    it('should return 404 on Prisma P2025 (record not found)', async () => {
+      const p2025Err = Object.assign(new Error('Record not found'), { code: 'P2025' });
+      mockTravelOnboardingProfileDelete.mockRejectedValue(p2025Err as never);
+
+      const res = await request(app)
+        .delete('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(404);
+
+      expect(res.body.error).toBeDefined();
+    });
+
+    it('should return 500 on internal error', async () => {
+      mockTravelOnboardingProfileDelete.mockRejectedValue(new Error('DB error') as never);
+
+      await request(app)
+        .delete('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(500);
+    });
+
+    it('should return 401 when auth middleware passes but user has no id', async () => {
+      mockUserFindUnique.mockResolvedValue({ email: testUserEmail, role: 'USER' } as never);
+
+      const res = await request(app)
+        .delete('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(401);
+
+      expect(res.body.error).toBeDefined();
+    });
+  });
+});

--- a/tests/DR-543-user-gdpr-services/unit/auditLogService.test.ts
+++ b/tests/DR-543-user-gdpr-services/unit/auditLogService.test.ts
@@ -1,0 +1,197 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+const mockDataAccessLogCreate = jest.fn();
+const mockDataAccessLogFindMany = jest.fn();
+
+jest.mock('@dreamscape/db', () => ({
+  prisma: {
+    dataAccessLog: {
+      create: mockDataAccessLogCreate,
+      findMany: mockDataAccessLogFindMany,
+    },
+  },
+  DataAccessAction: {
+    READ: 'READ',
+    CREATE: 'CREATE',
+    UPDATE: 'UPDATE',
+    DELETE: 'DELETE',
+  },
+}));
+
+import auditLogService from '../../../../dreamscape-services/user/src/services/AuditLogService';
+
+const userId = 'user-123';
+
+const mockLogEntry = {
+  id: 'log-1',
+  userId,
+  accessorId: 'user-123',
+  accessorType: 'user',
+  action: 'READ',
+  resource: 'UserProfile',
+  resourceId: null,
+  ipAddress: '127.0.0.1',
+  userAgent: 'Mozilla/5.0',
+  endpoint: '/api/v1/users/profile',
+  method: 'GET',
+  accessedAt: new Date(),
+};
+
+describe('AuditLogService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('logAccess', () => {
+    it('should create a log entry with all required fields', async () => {
+      mockDataAccessLogCreate.mockResolvedValue(mockLogEntry as never);
+
+      const input = {
+        userId,
+        accessorId: userId,
+        accessorType: 'user' as const,
+        action: 'READ' as any,
+        resource: 'UserProfile',
+        ipAddress: '127.0.0.1',
+        userAgent: 'Mozilla/5.0',
+        endpoint: '/api/v1/users/profile',
+        method: 'GET',
+      };
+
+      const result = await auditLogService.logAccess(input);
+
+      expect(mockDataAccessLogCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          userId,
+          accessorId: userId,
+          accessorType: 'user',
+          action: 'READ',
+          resource: 'UserProfile',
+          ipAddress: '127.0.0.1',
+          accessedAt: expect.any(Date),
+        }),
+      });
+      expect(result).toEqual(mockLogEntry);
+    });
+
+    it('should create a log entry with optional fields as undefined', async () => {
+      mockDataAccessLogCreate.mockResolvedValue(mockLogEntry as never);
+
+      await auditLogService.logAccess({
+        userId,
+        accessorType: 'user',
+        action: 'READ' as any,
+        resource: 'UserProfile',
+      });
+
+      expect(mockDataAccessLogCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          userId,
+          accessorId: undefined,
+          resourceId: undefined,
+          ipAddress: undefined,
+          userAgent: undefined,
+          endpoint: undefined,
+          method: undefined,
+        }),
+      });
+    });
+
+    it('should throw when prisma fails', async () => {
+      mockDataAccessLogCreate.mockRejectedValue(new Error('DB error') as never);
+
+      await expect(
+        auditLogService.logAccess({
+          userId,
+          accessorType: 'user',
+          action: 'READ' as any,
+          resource: 'UserProfile',
+        })
+      ).rejects.toThrow('Failed to log access: DB error');
+    });
+
+    it('should throw with "Unknown error" when a non-Error is thrown', async () => {
+      mockDataAccessLogCreate.mockRejectedValue('string error' as never);
+
+      await expect(
+        auditLogService.logAccess({
+          userId,
+          accessorType: 'user',
+          action: 'READ' as any,
+          resource: 'UserProfile',
+        })
+      ).rejects.toThrow('Failed to log access: Unknown error');
+    });
+  });
+
+  describe('getAccessLogs', () => {
+    it('should return all logs for a user without filters', async () => {
+      const logs = [mockLogEntry];
+      mockDataAccessLogFindMany.mockResolvedValue(logs as never);
+
+      const result = await auditLogService.getAccessLogs(userId);
+
+      expect(mockDataAccessLogFindMany).toHaveBeenCalledWith({
+        where: { userId },
+        orderBy: { accessedAt: 'desc' },
+        take: undefined,
+        skip: undefined,
+      });
+      expect(result).toEqual(logs);
+    });
+
+    it('should filter by resource when provided', async () => {
+      mockDataAccessLogFindMany.mockResolvedValue([mockLogEntry] as never);
+
+      await auditLogService.getAccessLogs(userId, { resource: 'UserProfile' });
+
+      expect(mockDataAccessLogFindMany).toHaveBeenCalledWith({
+        where: { userId, resource: 'UserProfile' },
+        orderBy: { accessedAt: 'desc' },
+        take: undefined,
+        skip: undefined,
+      });
+    });
+
+    it('should apply pagination (take/skip)', async () => {
+      mockDataAccessLogFindMany.mockResolvedValue([mockLogEntry] as never);
+
+      await auditLogService.getAccessLogs(userId, { limit: 10, offset: 20 });
+
+      expect(mockDataAccessLogFindMany).toHaveBeenCalledWith({
+        where: { userId },
+        orderBy: { accessedAt: 'desc' },
+        take: 10,
+        skip: 20,
+      });
+    });
+
+    it('should return empty array when no logs exist', async () => {
+      mockDataAccessLogFindMany.mockResolvedValue([] as never);
+
+      const result = await auditLogService.getAccessLogs(userId);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should throw when prisma fails', async () => {
+      mockDataAccessLogFindMany.mockRejectedValue(new Error('DB error') as never);
+
+      await expect(auditLogService.getAccessLogs(userId)).rejects.toThrow(
+        'Failed to get access logs: DB error'
+      );
+    });
+
+    it('should throw with "Unknown error" when a non-Error is thrown', async () => {
+      mockDataAccessLogFindMany.mockRejectedValue(null as never);
+
+      await expect(auditLogService.getAccessLogs(userId)).rejects.toThrow(
+        'Failed to get access logs: Unknown error'
+      );
+    });
+  });
+});

--- a/tests/DR-543-user-gdpr-services/unit/consentService.test.ts
+++ b/tests/DR-543-user-gdpr-services/unit/consentService.test.ts
@@ -1,0 +1,198 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+const mockUserConsentUpsert = jest.fn();
+const mockUserConsentUpdate = jest.fn();
+const mockUserConsentFindUnique = jest.fn();
+const mockConsentHistoryCreate = jest.fn();
+const mockConsentHistoryFindMany = jest.fn();
+
+jest.mock('@dreamscape/db', () => ({
+  prisma: {
+    userConsent: {
+      upsert: mockUserConsentUpsert,
+      update: mockUserConsentUpdate,
+      findUnique: mockUserConsentFindUnique,
+    },
+    consentHistory: {
+      create: mockConsentHistoryCreate,
+      findMany: mockConsentHistoryFindMany,
+    },
+  },
+}));
+
+import consentService from '../../../../dreamscape-services/user/src/services/ConsentService';
+
+const mockConsent = {
+  id: 'consent-id-1',
+  userId: 'user-123',
+  analytics: false,
+  marketing: false,
+  functional: true,
+  preferences: true,
+  lastUpdatedAt: new Date(),
+  ipAddress: null,
+};
+
+describe('ConsentService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('getUserConsent', () => {
+    it('should upsert consent with default values for new user', async () => {
+      mockUserConsentUpsert.mockResolvedValue(mockConsent as never);
+
+      const result = await consentService.getUserConsent('user-123');
+
+      expect(mockUserConsentUpsert).toHaveBeenCalledWith({
+        where: { userId: 'user-123' },
+        update: {},
+        create: {
+          userId: 'user-123',
+          analytics: false,
+          marketing: false,
+          functional: true,
+          preferences: true,
+        },
+      });
+      expect(result).toEqual(mockConsent);
+    });
+
+    it('should return existing consent record', async () => {
+      const existingConsent = { ...mockConsent, analytics: true, marketing: true };
+      mockUserConsentUpsert.mockResolvedValue(existingConsent as never);
+
+      const result = await consentService.getUserConsent('user-123');
+
+      expect(result.analytics).toBe(true);
+      expect(result.marketing).toBe(true);
+    });
+
+    it('should throw an error when prisma fails', async () => {
+      mockUserConsentUpsert.mockRejectedValue(new Error('DB error') as never);
+
+      await expect(consentService.getUserConsent('user-123')).rejects.toThrow(
+        'Failed to get user consent: DB error'
+      );
+    });
+
+    it('should throw with "Unknown error" when a non-Error is thrown', async () => {
+      mockUserConsentUpsert.mockRejectedValue('string error' as never);
+
+      await expect(consentService.getUserConsent('user-123')).rejects.toThrow(
+        'Failed to get user consent: Unknown error'
+      );
+    });
+  });
+
+  describe('updateConsent', () => {
+    const updatedConsent = { ...mockConsent, analytics: true, lastUpdatedAt: new Date() };
+
+    beforeEach(() => {
+      mockUserConsentUpsert.mockResolvedValue(mockConsent as never);
+      mockUserConsentUpdate.mockResolvedValue(updatedConsent as never);
+      mockConsentHistoryCreate.mockResolvedValue({} as never);
+    });
+
+    it('should update consent fields and create history entry', async () => {
+      const result = await consentService.updateConsent('user-123', { analytics: true });
+
+      expect(mockUserConsentUpdate).toHaveBeenCalledWith({
+        where: { userId: 'user-123' },
+        data: expect.objectContaining({ analytics: true }),
+      });
+      expect(mockConsentHistoryCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          consentId: mockConsent.id,
+          userId: 'user-123',
+          analytics: updatedConsent.analytics,
+        }),
+      });
+      expect(result).toEqual(updatedConsent);
+    });
+
+    it('should pass ipAddress and userAgent to update and history', async () => {
+      await consentService.updateConsent(
+        'user-123',
+        { marketing: true },
+        '192.168.1.1',
+        'Mozilla/5.0'
+      );
+
+      expect(mockUserConsentUpdate).toHaveBeenCalledWith({
+        where: { userId: 'user-123' },
+        data: expect.objectContaining({ ipAddress: '192.168.1.1' }),
+      });
+      expect(mockConsentHistoryCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          ipAddress: '192.168.1.1',
+          userAgent: 'Mozilla/5.0',
+        }),
+      });
+    });
+
+    it('should throw an error when update fails', async () => {
+      mockUserConsentUpdate.mockRejectedValue(new Error('Update failed') as never);
+
+      await expect(
+        consentService.updateConsent('user-123', { analytics: true })
+      ).rejects.toThrow('Failed to update consent');
+    });
+
+    it('should throw with "Unknown error" when a non-Error is thrown during update', async () => {
+      mockUserConsentUpdate.mockRejectedValue(42 as never);
+
+      await expect(
+        consentService.updateConsent('user-123', { analytics: true })
+      ).rejects.toThrow('Failed to update consent: Unknown error');
+    });
+  });
+
+  describe('getConsentHistory', () => {
+    it('should return empty array when no consent record exists', async () => {
+      mockUserConsentFindUnique.mockResolvedValue(null as never);
+
+      const result = await consentService.getConsentHistory('user-123');
+
+      expect(result).toEqual([]);
+      expect(mockConsentHistoryFindMany).not.toHaveBeenCalled();
+    });
+
+    it('should return ordered consent history', async () => {
+      const historyEntries = [
+        { id: 'h2', changedAt: new Date('2024-02-01') },
+        { id: 'h1', changedAt: new Date('2024-01-01') },
+      ];
+      mockUserConsentFindUnique.mockResolvedValue(mockConsent as never);
+      mockConsentHistoryFindMany.mockResolvedValue(historyEntries as never);
+
+      const result = await consentService.getConsentHistory('user-123');
+
+      expect(mockConsentHistoryFindMany).toHaveBeenCalledWith({
+        where: { userId: 'user-123' },
+        orderBy: { changedAt: 'desc' },
+      });
+      expect(result).toEqual(historyEntries);
+    });
+
+    it('should throw an error when prisma fails', async () => {
+      mockUserConsentFindUnique.mockRejectedValue(new Error('DB error') as never);
+
+      await expect(consentService.getConsentHistory('user-123')).rejects.toThrow(
+        'Failed to get consent history'
+      );
+    });
+
+    it('should throw with "Unknown error" when a non-Error is thrown in getConsentHistory', async () => {
+      mockUserConsentFindUnique.mockRejectedValue({ code: 'P2000' } as never);
+
+      await expect(consentService.getConsentHistory('user-123')).rejects.toThrow(
+        'Failed to get consent history: Unknown error'
+      );
+    });
+  });
+});

--- a/tests/DR-543-user-gdpr-services/unit/gdprRequestService.test.ts
+++ b/tests/DR-543-user-gdpr-services/unit/gdprRequestService.test.ts
@@ -1,0 +1,403 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+const mockGdprRequestCreate = jest.fn();
+const mockGdprRequestFindMany = jest.fn();
+const mockGdprRequestFindUnique = jest.fn();
+const mockGdprRequestUpdate = jest.fn();
+const mockUserFindUnique = jest.fn();
+
+jest.mock('@dreamscape/db', () => ({
+  prisma: {
+    gdprRequest: {
+      create: mockGdprRequestCreate,
+      findMany: mockGdprRequestFindMany,
+      findUnique: mockGdprRequestFindUnique,
+      update: mockGdprRequestUpdate,
+    },
+    user: {
+      findUnique: mockUserFindUnique,
+    },
+  },
+  GdprRequestType: {
+    DATA_EXPORT: 'DATA_EXPORT',
+    DATA_DELETION: 'DATA_DELETION',
+  },
+  GdprRequestStatus: {
+    PENDING: 'PENDING',
+    IN_PROGRESS: 'IN_PROGRESS',
+    COMPLETED: 'COMPLETED',
+    REJECTED: 'REJECTED',
+  },
+}));
+
+import gdprRequestService from '../../../../dreamscape-services/user/src/services/GdprRequestService';
+
+const userId = 'user-123';
+const requestId = 'req-456';
+
+const mockExportRequest = {
+  id: requestId,
+  userId,
+  requestType: 'DATA_EXPORT',
+  status: 'PENDING',
+  expiresAt: null,
+  processedAt: null,
+  completedAt: null,
+  exportData: null,
+  notes: null,
+  reason: null,
+  requestedAt: new Date(),
+};
+
+const mockCompletedRequest = {
+  ...mockExportRequest,
+  status: 'COMPLETED',
+  exportData: { user: { id: userId } },
+};
+
+const mockUserData = {
+  id: userId,
+  email: 'test@example.com',
+  username: 'testuser',
+  firstName: 'Test',
+  lastName: 'User',
+  phoneNumber: null,
+  dateOfBirth: null,
+  nationality: null,
+  userCategory: 'STANDARD',
+  isVerified: true,
+  role: 'USER',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  profile: null,
+  preferences: null,
+  settings: null,
+  favorites: [],
+  history: [],
+  travelOnboarding: null,
+  consent: null,
+  searches: [],
+  policyAcceptances: [],
+};
+
+describe('GdprRequestService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('requestDataExport', () => {
+    it('should create a DATA_EXPORT request with 30-day expiry', async () => {
+      mockGdprRequestCreate.mockResolvedValue(mockExportRequest as never);
+
+      const result = await gdprRequestService.requestDataExport(userId);
+
+      const call = (mockGdprRequestCreate as jest.Mock).mock.calls[0][0] as any;
+      expect(call.data.userId).toBe(userId);
+      expect(call.data.requestType).toBe('DATA_EXPORT');
+      expect(call.data.status).toBe('PENDING');
+      // expiresAt should be ~30 days from now
+      const diffDays = Math.round(
+        (call.data.expiresAt.getTime() - Date.now()) / (1000 * 60 * 60 * 24)
+      );
+      expect(diffDays).toBe(30);
+      expect(result).toEqual(mockExportRequest);
+    });
+
+    it('should throw an error when prisma fails', async () => {
+      mockGdprRequestCreate.mockRejectedValue(new Error('DB error') as never);
+
+      await expect(gdprRequestService.requestDataExport(userId)).rejects.toThrow(
+        'Failed to create data export request'
+      );
+    });
+
+    it('should throw with "Unknown error" when a non-Error is thrown', async () => {
+      mockGdprRequestCreate.mockRejectedValue('string error' as never);
+
+      await expect(gdprRequestService.requestDataExport(userId)).rejects.toThrow(
+        'Failed to create data export request: Unknown error'
+      );
+    });
+  });
+
+  describe('requestDataDeletion', () => {
+    it('should create a DATA_DELETION request without reason', async () => {
+      const deletionRequest = { ...mockExportRequest, requestType: 'DATA_DELETION', reason: null };
+      mockGdprRequestCreate.mockResolvedValue(deletionRequest as never);
+
+      const result = await gdprRequestService.requestDataDeletion(userId);
+
+      expect(mockGdprRequestCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          requestType: 'DATA_DELETION',
+          status: 'PENDING',
+          reason: undefined,
+        }),
+      });
+      expect(result.requestType).toBe('DATA_DELETION');
+    });
+
+    it('should create a DATA_DELETION request with reason', async () => {
+      const deletionRequest = { ...mockExportRequest, requestType: 'DATA_DELETION', reason: 'No longer needed' };
+      mockGdprRequestCreate.mockResolvedValue(deletionRequest as never);
+
+      await gdprRequestService.requestDataDeletion(userId, 'No longer needed');
+
+      expect(mockGdprRequestCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({ reason: 'No longer needed' }),
+      });
+    });
+
+    it('should throw an error when prisma fails', async () => {
+      mockGdprRequestCreate.mockRejectedValue(new Error('DB error') as never);
+
+      await expect(gdprRequestService.requestDataDeletion(userId)).rejects.toThrow(
+        'Failed to create data deletion request'
+      );
+    });
+
+    it('should throw with "Unknown error" when a non-Error is thrown', async () => {
+      mockGdprRequestCreate.mockRejectedValue(null as never);
+
+      await expect(gdprRequestService.requestDataDeletion(userId)).rejects.toThrow(
+        'Failed to create data deletion request: Unknown error'
+      );
+    });
+  });
+
+  describe('getUserRequests', () => {
+    it('should return empty array when no requests', async () => {
+      mockGdprRequestFindMany.mockResolvedValue([] as never);
+
+      const result = await gdprRequestService.getUserRequests(userId);
+
+      expect(result).toEqual([]);
+      expect(mockGdprRequestFindMany).toHaveBeenCalledWith({
+        where: { userId },
+        orderBy: { requestedAt: 'desc' },
+      });
+    });
+
+    it('should return all requests for a user ordered by date desc', async () => {
+      const requests = [mockExportRequest, { ...mockExportRequest, id: 'req-789' }];
+      mockGdprRequestFindMany.mockResolvedValue(requests as never);
+
+      const result = await gdprRequestService.getUserRequests(userId);
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('should throw an error when prisma fails', async () => {
+      mockGdprRequestFindMany.mockRejectedValue(new Error('DB error') as never);
+
+      await expect(gdprRequestService.getUserRequests(userId)).rejects.toThrow(
+        'Failed to get user requests'
+      );
+    });
+
+    it('should throw with "Unknown error" when a non-Error is thrown', async () => {
+      mockGdprRequestFindMany.mockRejectedValue(42 as never);
+
+      await expect(gdprRequestService.getUserRequests(userId)).rejects.toThrow(
+        'Failed to get user requests: Unknown error'
+      );
+    });
+  });
+
+  describe('getRequestById', () => {
+    it('should return request when found and userId matches', async () => {
+      mockGdprRequestFindUnique.mockResolvedValue(mockExportRequest as never);
+
+      const result = await gdprRequestService.getRequestById(requestId, userId);
+
+      expect(result).toEqual(mockExportRequest);
+    });
+
+    it('should throw when request is not found', async () => {
+      mockGdprRequestFindUnique.mockResolvedValue(null as never);
+
+      await expect(gdprRequestService.getRequestById(requestId, userId)).rejects.toThrow(
+        'Failed to get request'
+      );
+    });
+
+    it('should throw when request belongs to another user', async () => {
+      mockGdprRequestFindUnique.mockResolvedValue({
+        ...mockExportRequest,
+        userId: 'other-user',
+      } as never);
+
+      await expect(gdprRequestService.getRequestById(requestId, userId)).rejects.toThrow(
+        'Failed to get request'
+      );
+    });
+
+    it('should throw when prisma fails', async () => {
+      mockGdprRequestFindUnique.mockRejectedValue(new Error('DB error') as never);
+
+      await expect(gdprRequestService.getRequestById(requestId, userId)).rejects.toThrow(
+        'Failed to get request'
+      );
+    });
+
+    it('should throw with "Unknown error" when a non-Error is thrown', async () => {
+      mockGdprRequestFindUnique.mockRejectedValue({ code: 'P2000' } as never);
+
+      await expect(gdprRequestService.getRequestById(requestId, userId)).rejects.toThrow(
+        'Failed to get request: Unknown error'
+      );
+    });
+  });
+
+  describe('processExport', () => {
+    it('should process export through full sequence and return COMPLETED request', async () => {
+      mockGdprRequestFindUnique.mockResolvedValue(mockExportRequest as never);
+      mockGdprRequestUpdate
+        .mockResolvedValueOnce({ ...mockExportRequest, status: 'IN_PROGRESS' } as never)
+        .mockResolvedValueOnce(mockCompletedRequest as never);
+      mockUserFindUnique.mockResolvedValue(mockUserData as never);
+
+      const result = await gdprRequestService.processExport(requestId);
+
+      // Step 1: status updated to IN_PROGRESS
+      expect(mockGdprRequestUpdate).toHaveBeenNthCalledWith(1, {
+        where: { id: requestId },
+        data: expect.objectContaining({ status: 'IN_PROGRESS' }),
+      });
+      // Step 2: user data fetched with includes
+      expect(mockUserFindUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: userId },
+          include: expect.objectContaining({ profile: true, favorites: true }),
+        })
+      );
+      // Step 3: status updated to COMPLETED with exportData
+      expect(mockGdprRequestUpdate).toHaveBeenNthCalledWith(2, {
+        where: { id: requestId },
+        data: expect.objectContaining({
+          status: 'COMPLETED',
+          exportData: expect.any(Object),
+        }),
+      });
+      expect(result).toEqual(mockCompletedRequest);
+    });
+
+    it('should throw when request is not found', async () => {
+      mockGdprRequestFindUnique.mockResolvedValue(null as never);
+      mockGdprRequestUpdate.mockResolvedValue({} as never);
+
+      await expect(gdprRequestService.processExport(requestId)).rejects.toThrow(
+        'Failed to process export'
+      );
+    });
+
+    it('should throw and set REJECTED status when request type is not DATA_EXPORT', async () => {
+      mockGdprRequestFindUnique.mockResolvedValue({
+        ...mockExportRequest,
+        requestType: 'DATA_DELETION',
+      } as never);
+      mockGdprRequestUpdate.mockResolvedValue({} as never);
+
+      await expect(gdprRequestService.processExport(requestId)).rejects.toThrow(
+        'Failed to process export'
+      );
+      expect(mockGdprRequestUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: 'REJECTED' }),
+        })
+      );
+    });
+
+    it('should throw and set REJECTED status when user is not found', async () => {
+      mockGdprRequestFindUnique.mockResolvedValue(mockExportRequest as never);
+      mockGdprRequestUpdate.mockResolvedValueOnce({ status: 'IN_PROGRESS' } as never);
+      mockUserFindUnique.mockResolvedValue(null as never);
+      mockGdprRequestUpdate.mockResolvedValueOnce({} as never);
+
+      await expect(gdprRequestService.processExport(requestId)).rejects.toThrow(
+        'Failed to process export'
+      );
+    });
+
+    it('should throw with "Unknown error" when a non-Error is thrown in processExport', async () => {
+      mockGdprRequestFindUnique.mockResolvedValue(mockExportRequest as never);
+      mockGdprRequestUpdate
+        .mockResolvedValueOnce({ status: 'IN_PROGRESS' } as never)
+        .mockResolvedValueOnce({} as never);
+      mockUserFindUnique.mockRejectedValue('non-error value' as never);
+
+      await expect(gdprRequestService.processExport(requestId)).rejects.toThrow(
+        'Failed to process export: Unknown error'
+      );
+    });
+
+    it('should silently handle REJECTED status update failure in catch block', async () => {
+      mockGdprRequestFindUnique.mockResolvedValue(mockExportRequest as never);
+      mockGdprRequestUpdate
+        .mockResolvedValueOnce({ status: 'IN_PROGRESS' } as never)
+        .mockRejectedValueOnce(new Error('Update to REJECTED also failed') as never);
+      mockUserFindUnique.mockRejectedValue(new Error('User fetch failed') as never);
+
+      await expect(gdprRequestService.processExport(requestId)).rejects.toThrow(
+        'Failed to process export'
+      );
+    });
+  });
+
+  describe('getExportData', () => {
+    it('should return export data for a completed request', async () => {
+      mockGdprRequestFindUnique.mockResolvedValue(mockCompletedRequest as never);
+
+      const result = await gdprRequestService.getExportData(requestId, userId);
+
+      expect(result).toEqual(mockCompletedRequest.exportData);
+    });
+
+    it('should throw when export is not completed', async () => {
+      mockGdprRequestFindUnique.mockResolvedValue({
+        ...mockExportRequest,
+        status: 'PENDING',
+      } as never);
+
+      await expect(gdprRequestService.getExportData(requestId, userId)).rejects.toThrow(
+        'Failed to get export data'
+      );
+    });
+
+    it('should throw when export data is null', async () => {
+      mockGdprRequestFindUnique.mockResolvedValue({
+        ...mockExportRequest,
+        status: 'COMPLETED',
+        exportData: null,
+      } as never);
+
+      await expect(gdprRequestService.getExportData(requestId, userId)).rejects.toThrow(
+        'Failed to get export data'
+      );
+    });
+
+    it('should throw when request belongs to another user', async () => {
+      mockGdprRequestFindUnique.mockResolvedValue({
+        ...mockCompletedRequest,
+        userId: 'other-user',
+      } as never);
+
+      await expect(gdprRequestService.getExportData(requestId, userId)).rejects.toThrow(
+        'Failed to get export data'
+      );
+    });
+
+    it('should propagate inner "Unknown error" when getRequestById receives a non-Error', async () => {
+      // getRequestById catches the non-Error and wraps it; getExportData then re-wraps that Error
+      mockGdprRequestFindUnique.mockRejectedValue(999 as never);
+
+      await expect(gdprRequestService.getExportData(requestId, userId)).rejects.toThrow(
+        'Failed to get export data: Failed to get request: Unknown error'
+      );
+    });
+  });
+});

--- a/tests/DR-543-user-gdpr-services/unit/privacyPolicyService.test.ts
+++ b/tests/DR-543-user-gdpr-services/unit/privacyPolicyService.test.ts
@@ -1,0 +1,238 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+const mockPrivacyPolicyFindFirst = jest.fn();
+const mockPrivacyPolicyFindMany = jest.fn();
+const mockPrivacyPolicyFindUnique = jest.fn();
+const mockUserPolicyAcceptanceUpsert = jest.fn();
+const mockUserPolicyAcceptanceFindUnique = jest.fn();
+
+jest.mock('@dreamscape/db', () => ({
+  prisma: {
+    privacyPolicy: {
+      findFirst: mockPrivacyPolicyFindFirst,
+      findMany: mockPrivacyPolicyFindMany,
+      findUnique: mockPrivacyPolicyFindUnique,
+    },
+    userPolicyAcceptance: {
+      upsert: mockUserPolicyAcceptanceUpsert,
+      findUnique: mockUserPolicyAcceptanceFindUnique,
+    },
+  },
+}));
+
+import privacyPolicyService from '../../../../dreamscape-services/user/src/services/PrivacyPolicyService';
+
+const mockPolicy = {
+  id: 'policy-1',
+  version: '1.0',
+  content: 'Privacy policy content',
+  effectiveAt: new Date('2024-01-01'),
+};
+
+const mockAcceptance = {
+  userId: 'user-123',
+  policyId: 'policy-1',
+  policyVersion: '1.0',
+  acceptedAt: new Date(),
+  ipAddress: '127.0.0.1',
+  userAgent: 'Mozilla/5.0',
+};
+
+describe('PrivacyPolicyService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('getCurrentPolicy', () => {
+    it('should return the most recent active policy', async () => {
+      mockPrivacyPolicyFindFirst.mockResolvedValue(mockPolicy as never);
+
+      const result = await privacyPolicyService.getCurrentPolicy();
+
+      expect(mockPrivacyPolicyFindFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { effectiveAt: { lte: expect.any(Date) } },
+          orderBy: { effectiveAt: 'desc' },
+        })
+      );
+      expect(result).toEqual(mockPolicy);
+    });
+
+    it('should throw when no active policy is found', async () => {
+      mockPrivacyPolicyFindFirst.mockResolvedValue(null as never);
+
+      await expect(privacyPolicyService.getCurrentPolicy()).rejects.toThrow(
+        'Failed to get current policy'
+      );
+    });
+
+    it('should throw when prisma fails', async () => {
+      mockPrivacyPolicyFindFirst.mockRejectedValue(new Error('DB error') as never);
+
+      await expect(privacyPolicyService.getCurrentPolicy()).rejects.toThrow(
+        'Failed to get current policy'
+      );
+    });
+
+    it('should throw with "Unknown error" when a non-Error is thrown', async () => {
+      mockPrivacyPolicyFindFirst.mockRejectedValue('string error' as never);
+
+      await expect(privacyPolicyService.getCurrentPolicy()).rejects.toThrow(
+        'Failed to get current policy: Unknown error'
+      );
+    });
+  });
+
+  describe('getAllVersions', () => {
+    it('should return all policy versions ordered by effectiveAt DESC', async () => {
+      const policies = [
+        { ...mockPolicy, id: 'policy-2', version: '2.0' },
+        mockPolicy,
+      ];
+      mockPrivacyPolicyFindMany.mockResolvedValue(policies as never);
+
+      const result = await privacyPolicyService.getAllVersions();
+
+      expect(mockPrivacyPolicyFindMany).toHaveBeenCalledWith({
+        orderBy: { effectiveAt: 'desc' },
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0].version).toBe('2.0');
+    });
+
+    it('should return empty array when no policies exist', async () => {
+      mockPrivacyPolicyFindMany.mockResolvedValue([] as never);
+
+      const result = await privacyPolicyService.getAllVersions();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should throw when prisma fails', async () => {
+      mockPrivacyPolicyFindMany.mockRejectedValue(new Error('DB error') as never);
+
+      await expect(privacyPolicyService.getAllVersions()).rejects.toThrow(
+        'Failed to get policy versions'
+      );
+    });
+
+    it('should throw with "Unknown error" when a non-Error is thrown', async () => {
+      mockPrivacyPolicyFindMany.mockRejectedValue(null as never);
+
+      await expect(privacyPolicyService.getAllVersions()).rejects.toThrow(
+        'Failed to get policy versions: Unknown error'
+      );
+    });
+  });
+
+  describe('acceptPolicy', () => {
+    it('should upsert an acceptance record with ipAddress and userAgent', async () => {
+      mockPrivacyPolicyFindUnique.mockResolvedValue(mockPolicy as never);
+      mockUserPolicyAcceptanceUpsert.mockResolvedValue(mockAcceptance as never);
+
+      const result = await privacyPolicyService.acceptPolicy(
+        'user-123',
+        'policy-1',
+        '127.0.0.1',
+        'Mozilla/5.0'
+      );
+
+      expect(mockUserPolicyAcceptanceUpsert).toHaveBeenCalledWith({
+        where: { userId_policyId: { userId: 'user-123', policyId: 'policy-1' } },
+        update: expect.objectContaining({ ipAddress: '127.0.0.1', userAgent: 'Mozilla/5.0' }),
+        create: expect.objectContaining({
+          userId: 'user-123',
+          policyId: 'policy-1',
+          policyVersion: '1.0',
+        }),
+      });
+      expect(result).toEqual(mockAcceptance);
+    });
+
+    it('should work without optional ipAddress and userAgent', async () => {
+      mockPrivacyPolicyFindUnique.mockResolvedValue(mockPolicy as never);
+      mockUserPolicyAcceptanceUpsert.mockResolvedValue(mockAcceptance as never);
+
+      await privacyPolicyService.acceptPolicy('user-123', 'policy-1');
+
+      expect(mockUserPolicyAcceptanceUpsert).toHaveBeenCalled();
+    });
+
+    it('should throw when policy is not found', async () => {
+      mockPrivacyPolicyFindUnique.mockResolvedValue(null as never);
+
+      await expect(
+        privacyPolicyService.acceptPolicy('user-123', 'policy-nonexistent')
+      ).rejects.toThrow('Failed to accept policy');
+    });
+
+    it('should throw when prisma fails', async () => {
+      mockPrivacyPolicyFindUnique.mockRejectedValue(new Error('DB error') as never);
+
+      await expect(
+        privacyPolicyService.acceptPolicy('user-123', 'policy-1')
+      ).rejects.toThrow('Failed to accept policy');
+    });
+
+    it('should throw with "Unknown error" when a non-Error is thrown', async () => {
+      mockPrivacyPolicyFindUnique.mockRejectedValue(123 as never);
+
+      await expect(
+        privacyPolicyService.acceptPolicy('user-123', 'policy-1')
+      ).rejects.toThrow('Failed to accept policy: Unknown error');
+    });
+  });
+
+  describe('hasAcceptedCurrentPolicy', () => {
+    it('should return true when user has accepted current policy', async () => {
+      mockPrivacyPolicyFindFirst.mockResolvedValue(mockPolicy as never);
+      mockUserPolicyAcceptanceFindUnique.mockResolvedValue(mockAcceptance as never);
+
+      const result = await privacyPolicyService.hasAcceptedCurrentPolicy('user-123');
+
+      expect(result).toBe(true);
+      expect(mockUserPolicyAcceptanceFindUnique).toHaveBeenCalledWith({
+        where: { userId_policyId: { userId: 'user-123', policyId: 'policy-1' } },
+      });
+    });
+
+    it('should return false when user has NOT accepted current policy', async () => {
+      mockPrivacyPolicyFindFirst.mockResolvedValue(mockPolicy as never);
+      mockUserPolicyAcceptanceFindUnique.mockResolvedValue(null as never);
+
+      const result = await privacyPolicyService.hasAcceptedCurrentPolicy('user-123');
+
+      expect(result).toBe(false);
+    });
+
+    it('should throw when there is no active policy', async () => {
+      mockPrivacyPolicyFindFirst.mockResolvedValue(null as never);
+
+      await expect(
+        privacyPolicyService.hasAcceptedCurrentPolicy('user-123')
+      ).rejects.toThrow('Failed to check policy acceptance');
+    });
+
+    it('should throw when prisma fails', async () => {
+      mockPrivacyPolicyFindFirst.mockRejectedValue(new Error('DB error') as never);
+
+      await expect(
+        privacyPolicyService.hasAcceptedCurrentPolicy('user-123')
+      ).rejects.toThrow('Failed to check policy acceptance');
+    });
+
+    it('should throw with "Unknown error" when findUnique throws a non-Error', async () => {
+      // getCurrentPolicy succeeds, then userPolicyAcceptance.findUnique throws a non-Error
+      mockPrivacyPolicyFindFirst.mockResolvedValue(mockPolicy as never);
+      mockUserPolicyAcceptanceFindUnique.mockRejectedValue(42 as never);
+
+      await expect(
+        privacyPolicyService.hasAcceptedCurrentPolicy('user-123')
+      ).rejects.toThrow('Failed to check policy acceptance: Unknown error');
+    });
+  });
+});

--- a/tests/DR-544-user-routes/unit/activities.routes.test.ts
+++ b/tests/DR-544-user-routes/unit/activities.routes.test.ts
@@ -1,0 +1,154 @@
+import request from 'supertest';
+import express, { Express } from 'express';
+import { jest, describe, it, expect, beforeAll, beforeEach, afterEach } from '@jest/globals';
+
+// ── AmadeusService mock ───────────────────────────────────────────────────────
+const mockSearchActivities = jest.fn();
+const mockGetActivityDetails = jest.fn();
+
+jest.mock('../../../../dreamscape-services/user/src/services/AmadeusService', () => ({
+  __esModule: true,
+  default: {
+    searchActivities: mockSearchActivities,
+    getActivityDetails: mockGetActivityDetails,
+  },
+}));
+
+import activitiesRouter from '../../../../dreamscape-services/user/src/routes/activities';
+
+// ── Test data ─────────────────────────────────────────────────────────────────
+const mockActivity = {
+  id: 'activity-1',
+  name: 'Eiffel Tower Tour',
+  description: 'A guided tour of the Eiffel Tower',
+  price: { amount: '25.00', currencyCode: 'EUR' },
+  location: { latitude: 48.8584, longitude: 2.2945 },
+};
+
+describe('Activities Routes', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/v1/users/activities', activitiesRouter);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // ─── GET /search ───────────────────────────────────────────────────────────
+  describe('GET /search', () => {
+    it('should return 400 when no coordinates are provided', async () => {
+      const res = await request(app)
+        .get('/api/v1/users/activities/search')
+        .expect(400);
+
+      expect(res.body.error).toContain('coordinates');
+    });
+
+    it('should return 200 with results using lat/lng', async () => {
+      mockSearchActivities.mockResolvedValue([mockActivity] as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/activities/search')
+        .query({ latitude: '48.8584', longitude: '2.2945' })
+        .expect(200);
+
+      expect(mockSearchActivities).toHaveBeenCalledWith(
+        expect.objectContaining({ latitude: 48.8584, longitude: 2.2945 })
+      );
+      expect(res.body).toEqual([mockActivity]);
+    });
+
+    it('should return 200 with results using bounding box', async () => {
+      mockSearchActivities.mockResolvedValue([mockActivity] as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/activities/search')
+        .query({ north: '49.0', west: '2.0', south: '48.5', east: '2.5' })
+        .expect(200);
+
+      expect(mockSearchActivities).toHaveBeenCalledWith(
+        expect.objectContaining({ north: 49.0, west: 2.0, south: 48.5, east: 2.5 })
+      );
+    });
+
+    it('should pass radius when provided', async () => {
+      mockSearchActivities.mockResolvedValue([] as never);
+
+      await request(app)
+        .get('/api/v1/users/activities/search')
+        .query({ latitude: '48.8584', longitude: '2.2945', radius: '5' })
+        .expect(200);
+
+      expect(mockSearchActivities).toHaveBeenCalledWith(
+        expect.objectContaining({ radius: 5 })
+      );
+    });
+
+    it('should return 500 on service error', async () => {
+      mockSearchActivities.mockRejectedValue(new Error('Amadeus API error') as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/activities/search')
+        .query({ latitude: '48.8584', longitude: '2.2945' })
+        .expect(500);
+
+      expect(res.body.error).toContain('Failed to search activities');
+    });
+  });
+
+  // ─── GET /details/:activityId ──────────────────────────────────────────────
+  describe('GET /details/:activityId', () => {
+    it('should return 200 with activity details', async () => {
+      mockGetActivityDetails.mockResolvedValue(mockActivity as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/activities/details/activity-1')
+        .expect(200);
+
+      expect(mockGetActivityDetails).toHaveBeenCalledWith('activity-1');
+      expect(res.body).toEqual(mockActivity);
+    });
+
+    it('should return 500 on service error', async () => {
+      mockGetActivityDetails.mockRejectedValue(new Error('Not found') as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/activities/details/unknown-id')
+        .expect(500);
+
+      expect(res.body.error).toContain('Failed to get activity details');
+    });
+  });
+
+  // ─── GET /:activityId ──────────────────────────────────────────────────────
+  describe('GET /:activityId', () => {
+    it('should return 200 with activity by ID', async () => {
+      mockGetActivityDetails.mockResolvedValue(mockActivity as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/activities/activity-1')
+        .expect(200);
+
+      expect(mockGetActivityDetails).toHaveBeenCalledWith('activity-1');
+      expect(res.body).toEqual(mockActivity);
+    });
+
+    it('should return 500 on service error', async () => {
+      mockGetActivityDetails.mockRejectedValue(new Error('Service error') as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/activities/bad-id')
+        .expect(500);
+
+      expect(res.body.error).toContain('Failed to get activity by ID');
+    });
+  });
+});

--- a/tests/DR-544-user-routes/unit/aiIntegration.routes.test.ts
+++ b/tests/DR-544-user-routes/unit/aiIntegration.routes.test.ts
@@ -1,0 +1,268 @@
+import request from 'supertest';
+import express, { Express } from 'express';
+import { jest, describe, it, expect, beforeAll, beforeEach, afterEach } from '@jest/globals';
+
+// ── Prisma mock ───────────────────────────────────────────────────────────────
+const mockUserFindUnique = jest.fn();
+const mockUserFindMany = jest.fn();
+const mockUserCount = jest.fn();
+const mockTravelOnboardingProfileCount = jest.fn();
+const mockAnalyticsCreate = jest.fn();
+const mockAnalyticsCount = jest.fn();
+
+jest.mock('@dreamscape/db', () => ({
+  prisma: {
+    user: {
+      findUnique: mockUserFindUnique,
+      findMany: mockUserFindMany,
+      count: mockUserCount,
+    },
+    travelOnboardingProfile: {
+      count: mockTravelOnboardingProfileCount,
+    },
+    analytics: {
+      create: mockAnalyticsCreate,
+      count: mockAnalyticsCount,
+    },
+  },
+}));
+
+import aiIntegrationRouter from '../../../../dreamscape-services/user/src/routes/aiIntegration';
+
+// ── Test data ─────────────────────────────────────────────────────────────────
+const userId = 'user-123';
+
+const mockUser = {
+  id: userId,
+  email: 'test@example.com',
+  onboardingCompleted: true,
+  onboardingCompletedAt: new Date(),
+  updatedAt: new Date(),
+  travelOnboarding: {
+    id: 'profile-1',
+    userId,
+    isCompleted: true,
+    completedSteps: ['destinations', 'budget', 'travel_types'],
+    version: 1,
+    travelTypes: ['ADVENTURE'],
+    accommodationTypes: ['HOTEL'],
+    preferredDestinations: { regions: ['Europe'], countries: ['France'], climates: ['temperate'] },
+    globalBudgetRange: { min: 500, max: 2000, currency: 'EUR' },
+    budgetByCategory: null,
+    travelStyle: 'PLANNED',
+    comfortLevel: null,
+    accommodationLevel: 'STANDARD',
+    activityLevel: 'MODERATE',
+    riskTolerance: 'MODERATE',
+    budgetFlexibility: 'FLEXIBLE',
+    dateFlexibility: 'FLEXIBLE',
+    travelGroupTypes: [],
+    travelWithChildren: false,
+    childrenAges: [],
+    preferredSeasons: ['SPRING'],
+    weatherTolerances: null,
+    preferredTripDuration: null,
+    roomPreferences: null,
+    groupSize: null,
+    loyaltyPrograms: null,
+    paymentPreferences: [],
+    preferredAirlines: [],
+    cabinClassPreference: null,
+    transportModes: [],
+    transportBudgetShare: null,
+    activityTypes: ['hiking'],
+    interestCategories: ['culture'],
+    dietaryRequirements: [],
+    accessibilityNeeds: [],
+    healthConsiderations: [],
+    culturalConsiderations: [],
+    languageBarriers: [],
+    experienceLevel: null,
+    culturalImmersion: null,
+    climatePreferences: [],
+    travelPurposes: [],
+    serviceLevel: null,
+    privacyPreference: null,
+    updatedAt: new Date(),
+  },
+  settings: null,
+  preferences: null,
+};
+
+describe('AI Integration Routes', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/v1/ai', aiIntegrationRouter);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAnalyticsCreate.mockResolvedValue({} as never);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // ─── GET /users/:userId/preferences ───────────────────────────────────────
+  describe('GET /users/:userId/preferences', () => {
+    it('should return 404 when user does not exist', async () => {
+      mockUserFindUnique.mockResolvedValue(null as never);
+
+      const res = await request(app)
+        .get(`/api/v1/ai/users/${userId}/preferences`)
+        .expect(404);
+
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should return 200 with AI-formatted preferences', async () => {
+      mockUserFindUnique.mockResolvedValue(mockUser as never);
+
+      const res = await request(app)
+        .get(`/api/v1/ai/users/${userId}/preferences`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.userId).toBe(userId);
+      expect(res.body.data.preferences).toBeDefined();
+      expect(res.body.data.metadata).toBeDefined();
+    });
+
+    it('should return 200 with empty preferences when user has no onboarding', async () => {
+      mockUserFindUnique.mockResolvedValue({ ...mockUser, travelOnboarding: null } as never);
+
+      const res = await request(app)
+        .get(`/api/v1/ai/users/${userId}/preferences`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.preferences.destinations.regions).toEqual([]);
+    });
+
+    it('should return 500 on internal error', async () => {
+      mockUserFindUnique.mockRejectedValue(new Error('DB error') as never);
+
+      const res = await request(app)
+        .get(`/api/v1/ai/users/${userId}/preferences`)
+        .expect(500);
+
+      expect(res.body.success).toBe(false);
+    });
+  });
+
+  // ─── POST /users/preferences/batch ────────────────────────────────────────
+  describe('POST /users/preferences/batch', () => {
+    it('should return 400 when userIds is not an array', async () => {
+      const res = await request(app)
+        .post('/api/v1/ai/users/preferences/batch')
+        .send({ userIds: 'not-array' })
+        .expect(400);
+
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should return 400 when userIds is empty', async () => {
+      const res = await request(app)
+        .post('/api/v1/ai/users/preferences/batch')
+        .send({ userIds: [] })
+        .expect(400);
+
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should return 400 when more than 100 userIds are provided', async () => {
+      const userIds = Array.from({ length: 101 }, (_, i) => `user-${i}`);
+
+      const res = await request(app)
+        .post('/api/v1/ai/users/preferences/batch')
+        .send({ userIds })
+        .expect(400);
+
+      expect(res.body.error).toContain('Maximum 100');
+    });
+
+    it('should return 200 with batch preferences and meta', async () => {
+      mockUserFindMany.mockResolvedValue([mockUser] as never);
+
+      const res = await request(app)
+        .post('/api/v1/ai/users/preferences/batch')
+        .send({ userIds: [userId] })
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.users).toHaveLength(1);
+      expect(res.body.data.meta.requested).toBe(1);
+      expect(res.body.data.meta.found).toBe(1);
+    });
+
+    it('should report not-found users in meta', async () => {
+      mockUserFindMany.mockResolvedValue([mockUser] as never);
+
+      const res = await request(app)
+        .post('/api/v1/ai/users/preferences/batch')
+        .send({ userIds: [userId, 'missing-user'] })
+        .expect(200);
+
+      expect(res.body.data.meta.notFound).toContain('missing-user');
+    });
+
+    it('should return 500 on internal error', async () => {
+      mockUserFindMany.mockRejectedValue(new Error('DB error') as never);
+
+      const res = await request(app)
+        .post('/api/v1/ai/users/preferences/batch')
+        .send({ userIds: [userId] })
+        .expect(500);
+
+      expect(res.body.success).toBe(false);
+    });
+  });
+
+  // ─── GET /health ───────────────────────────────────────────────────────────
+  describe('GET /health', () => {
+    beforeEach(() => {
+      mockUserCount
+        .mockResolvedValueOnce(100 as never)
+        .mockResolvedValueOnce(60 as never);
+      mockTravelOnboardingProfileCount
+        .mockResolvedValueOnce(80 as never)
+        .mockResolvedValueOnce(50 as never);
+      mockAnalyticsCount.mockResolvedValue(25 as never);
+    });
+
+    it('should return 200 with health data structure', async () => {
+      const res = await request(app)
+        .get('/api/v1/ai/health')
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.totalUsers).toBeDefined();
+      expect(res.body.data.onboardingStats).toBeDefined();
+      expect(res.body.data.healthStatus).toBeDefined();
+    });
+
+    it('should return healthStatus "healthy" when completedProfiles > 0', async () => {
+      const res = await request(app)
+        .get('/api/v1/ai/health')
+        .expect(200);
+
+      expect(res.body.data.healthStatus.overall).toBe('healthy');
+    });
+
+    it('should return 500 on internal error', async () => {
+      jest.resetAllMocks();
+      mockUserCount.mockRejectedValue(new Error('DB error') as never);
+      mockAnalyticsCreate.mockResolvedValue({} as never);
+
+      const res = await request(app)
+        .get('/api/v1/ai/health')
+        .expect(500);
+
+      expect(res.body.success).toBe(false);
+    });
+  });
+});

--- a/tests/DR-544-user-routes/unit/gdpr.routes.test.ts
+++ b/tests/DR-544-user-routes/unit/gdpr.routes.test.ts
@@ -1,0 +1,435 @@
+import request from 'supertest';
+import express, { Express } from 'express';
+import { jest, describe, it, expect, beforeAll, beforeEach, afterEach } from '@jest/globals';
+
+// ── Auth middleware mock (gdpr.ts uses relative '../middleware/auth') ──────────
+const userId = 'user-123';
+let authShouldReject = false;
+
+jest.mock('../../../../dreamscape-services/user/src/middleware/auth', () => ({
+  authenticateToken: (req: any, res: any, next: any) => {
+    if (authShouldReject) {
+      return res.status(401).json({ success: false, message: 'Access token required' });
+    }
+    req.user = { id: userId, email: 'test@example.com', role: 'user' };
+    next();
+  },
+}));
+
+// ── Service mocks ─────────────────────────────────────────────────────────────
+const mockConsentServiceGetUserConsent = jest.fn();
+const mockConsentServiceUpdateConsent = jest.fn();
+const mockConsentServiceGetConsentHistory = jest.fn();
+
+jest.mock('../../../../dreamscape-services/user/src/services/ConsentService', () => ({
+  __esModule: true,
+  default: {
+    getUserConsent: mockConsentServiceGetUserConsent,
+    updateConsent: mockConsentServiceUpdateConsent,
+    getConsentHistory: mockConsentServiceGetConsentHistory,
+  },
+}));
+
+const mockPrivacyPolicyGetCurrent = jest.fn();
+const mockPrivacyPolicyGetAllVersions = jest.fn();
+const mockPrivacyPolicyAccept = jest.fn();
+
+jest.mock('../../../../dreamscape-services/user/src/services/PrivacyPolicyService', () => ({
+  __esModule: true,
+  default: {
+    getCurrentPolicy: mockPrivacyPolicyGetCurrent,
+    getAllVersions: mockPrivacyPolicyGetAllVersions,
+    acceptPolicy: mockPrivacyPolicyAccept,
+  },
+}));
+
+const mockGdprRequestDataExport = jest.fn();
+const mockGdprRequestDataDeletion = jest.fn();
+const mockGdprRequestGetUserRequests = jest.fn();
+const mockGdprRequestGetRequestById = jest.fn();
+const mockGdprRequestProcessExport = jest.fn();
+const mockGdprRequestGetExportData = jest.fn();
+
+jest.mock('../../../../dreamscape-services/user/src/services/GdprRequestService', () => ({
+  __esModule: true,
+  default: {
+    requestDataExport: mockGdprRequestDataExport,
+    requestDataDeletion: mockGdprRequestDataDeletion,
+    getUserRequests: mockGdprRequestGetUserRequests,
+    getRequestById: mockGdprRequestGetRequestById,
+    processExport: mockGdprRequestProcessExport,
+    getExportData: mockGdprRequestGetExportData,
+  },
+}));
+
+// ── Kafka mock ────────────────────────────────────────────────────────────────
+const mockPublishConsentUpdated = jest.fn().mockResolvedValue(undefined as never);
+const mockPublishGdprExportRequested = jest.fn().mockResolvedValue(undefined as never);
+const mockPublishGdprDeletionRequested = jest.fn().mockResolvedValue(undefined as never);
+
+jest.mock('../../../../dreamscape-services/user/src/services/KafkaService', () => ({
+  userKafkaService: {
+    publishConsentUpdated: mockPublishConsentUpdated,
+    publishGdprExportRequested: mockPublishGdprExportRequested,
+    publishGdprDeletionRequested: mockPublishGdprDeletionRequested,
+  },
+}));
+
+import gdprRouter from '../../../../dreamscape-services/user/src/routes/gdpr';
+
+// ── Test data ─────────────────────────────────────────────────────────────────
+const mockPolicy = {
+  id: 'policy-1',
+  version: '1.0',
+  content: 'Privacy policy content',
+  effectiveAt: new Date('2024-01-01'),
+};
+
+const mockConsent = {
+  id: 'consent-1',
+  userId,
+  analytics: false,
+  marketing: false,
+  functional: true,
+  preferences: true,
+  lastUpdatedAt: new Date(),
+  createdAt: new Date(),
+};
+
+const mockGdprRequest = {
+  id: 'req-1',
+  userId,
+  requestType: 'DATA_EXPORT',
+  status: 'PENDING',
+  requestedAt: new Date(),
+  expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+  processedAt: null,
+  completedAt: null,
+  exportData: null,
+  notes: null,
+  reason: null,
+};
+
+describe('GDPR Routes', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/v1/users/gdpr', gdprRouter);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authShouldReject = false;
+    mockPublishConsentUpdated.mockResolvedValue(undefined as never);
+    mockPublishGdprExportRequested.mockResolvedValue(undefined as never);
+    mockPublishGdprDeletionRequested.mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // ─── GET /privacy-policy (public) ─────────────────────────────────────────
+  describe('GET /privacy-policy', () => {
+    it('should return 200 with the current policy', async () => {
+      mockPrivacyPolicyGetCurrent.mockResolvedValue(mockPolicy as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/gdpr/privacy-policy')
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.id).toBe('policy-1');
+    });
+
+    it('should return 404 when no active policy exists', async () => {
+      mockPrivacyPolicyGetCurrent.mockRejectedValue(
+        new Error('No active privacy policy found') as never
+      );
+
+      const res = await request(app)
+        .get('/api/v1/users/gdpr/privacy-policy')
+        .expect(404);
+
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should return 500 on unexpected error', async () => {
+      mockPrivacyPolicyGetCurrent.mockRejectedValue(new Error('DB error') as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/gdpr/privacy-policy')
+        .expect(500);
+
+      expect(res.body.success).toBe(false);
+    });
+  });
+
+  // ─── GET /privacy-policy/versions (public) ────────────────────────────────
+  describe('GET /privacy-policy/versions', () => {
+    it('should return 200 with all policy versions', async () => {
+      mockPrivacyPolicyGetAllVersions.mockResolvedValue([mockPolicy] as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/gdpr/privacy-policy/versions')
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(Array.isArray(res.body.data)).toBe(true);
+    });
+  });
+
+  // ─── POST /privacy-policy/accept (auth required) ──────────────────────────
+  describe('POST /privacy-policy/accept', () => {
+    it('should return 401 when not authenticated', async () => {
+      authShouldReject = true;
+
+      const res = await request(app)
+        .post('/api/v1/users/gdpr/privacy-policy/accept')
+        .send({ policyId: 'policy-1' })
+        .expect(401);
+
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should return 400 when policyId is missing', async () => {
+      const res = await request(app)
+        .post('/api/v1/users/gdpr/privacy-policy/accept')
+        .send({})
+        .expect(400);
+
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should return 200 on successful acceptance', async () => {
+      const mockAcceptance = { userId, policyId: 'policy-1', policyVersion: '1.0', acceptedAt: new Date() };
+      mockPrivacyPolicyAccept.mockResolvedValue(mockAcceptance as never);
+
+      const res = await request(app)
+        .post('/api/v1/users/gdpr/privacy-policy/accept')
+        .send({ policyId: 'policy-1' })
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+    });
+  });
+
+  // ─── GET /consent ──────────────────────────────────────────────────────────
+  describe('GET /consent', () => {
+    it('should return 401 when not authenticated', async () => {
+      authShouldReject = true;
+      const res = await request(app).get('/api/v1/users/gdpr/consent').expect(401);
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should return 200 with user consent', async () => {
+      mockConsentServiceGetUserConsent.mockResolvedValue(mockConsent as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/gdpr/consent')
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.userId).toBe(userId);
+    });
+  });
+
+  // ─── PUT /consent ──────────────────────────────────────────────────────────
+  describe('PUT /consent', () => {
+    it('should return 401 when not authenticated', async () => {
+      authShouldReject = true;
+      await request(app).put('/api/v1/users/gdpr/consent').send({ analytics: true }).expect(401);
+    });
+
+    it('should return 400 when no field is provided', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/gdpr/consent')
+        .send({})
+        .expect(400);
+
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toContain('At least one');
+    });
+
+    it('should return 400 when analytics is not boolean', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/gdpr/consent')
+        .send({ analytics: 'yes' })
+        .expect(400);
+
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should return 200 and trigger Kafka event on success', async () => {
+      const updatedConsent = { ...mockConsent, analytics: true };
+      mockConsentServiceUpdateConsent.mockResolvedValue(updatedConsent as never);
+
+      const res = await request(app)
+        .put('/api/v1/users/gdpr/consent')
+        .send({ analytics: true })
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(mockPublishConsentUpdated).toHaveBeenCalled();
+    });
+  });
+
+  // ─── GET /consent/history ──────────────────────────────────────────────────
+  describe('GET /consent/history', () => {
+    it('should return 401 when not authenticated', async () => {
+      authShouldReject = true;
+      await request(app).get('/api/v1/users/gdpr/consent/history').expect(401);
+    });
+
+    it('should return 200 with consent history', async () => {
+      mockConsentServiceGetConsentHistory.mockResolvedValue([] as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/gdpr/consent/history')
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(Array.isArray(res.body.data)).toBe(true);
+    });
+  });
+
+  // ─── POST /data-export ─────────────────────────────────────────────────────
+  describe('POST /data-export', () => {
+    it('should return 401 when not authenticated', async () => {
+      authShouldReject = true;
+      await request(app).post('/api/v1/users/gdpr/data-export').expect(401);
+    });
+
+    it('should return 201 and trigger Kafka event on success', async () => {
+      mockGdprRequestDataExport.mockResolvedValue(mockGdprRequest as never);
+      mockGdprRequestProcessExport.mockResolvedValue({ ...mockGdprRequest, status: 'COMPLETED' } as never);
+
+      const res = await request(app)
+        .post('/api/v1/users/gdpr/data-export')
+        .expect(201);
+
+      expect(res.body.success).toBe(true);
+      expect(mockPublishGdprExportRequested).toHaveBeenCalled();
+    });
+  });
+
+  // ─── POST /data-deletion ───────────────────────────────────────────────────
+  describe('POST /data-deletion', () => {
+    it('should return 401 when not authenticated', async () => {
+      authShouldReject = true;
+      await request(app).post('/api/v1/users/gdpr/data-deletion').expect(401);
+    });
+
+    it('should return 201 with optional reason', async () => {
+      const deletionReq = { ...mockGdprRequest, requestType: 'DATA_DELETION' };
+      mockGdprRequestDataDeletion.mockResolvedValue(deletionReq as never);
+
+      const res = await request(app)
+        .post('/api/v1/users/gdpr/data-deletion')
+        .send({ reason: 'No longer needed' })
+        .expect(201);
+
+      expect(res.body.success).toBe(true);
+      expect(mockPublishGdprDeletionRequested).toHaveBeenCalled();
+    });
+
+    it('should return 400 when reason is not a string', async () => {
+      const res = await request(app)
+        .post('/api/v1/users/gdpr/data-deletion')
+        .send({ reason: 123 })
+        .expect(400);
+
+      expect(res.body.success).toBe(false);
+    });
+  });
+
+  // ─── GET /requests ─────────────────────────────────────────────────────────
+  describe('GET /requests', () => {
+    it('should return 401 when not authenticated', async () => {
+      authShouldReject = true;
+      await request(app).get('/api/v1/users/gdpr/requests').expect(401);
+    });
+
+    it('should return 200 with list of requests', async () => {
+      mockGdprRequestGetUserRequests.mockResolvedValue([mockGdprRequest] as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/gdpr/requests')
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(Array.isArray(res.body.data)).toBe(true);
+    });
+  });
+
+  // ─── GET /requests/:id ─────────────────────────────────────────────────────
+  describe('GET /requests/:id', () => {
+    it('should return 401 when not authenticated', async () => {
+      authShouldReject = true;
+      await request(app).get('/api/v1/users/gdpr/requests/req-1').expect(401);
+    });
+
+    it('should return 200 with the request', async () => {
+      mockGdprRequestGetRequestById.mockResolvedValue(mockGdprRequest as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/gdpr/requests/req-1')
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+    });
+
+    it('should return 404 when request not found', async () => {
+      mockGdprRequestGetRequestById.mockRejectedValue(new Error('Request not found') as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/gdpr/requests/missing')
+        .expect(404);
+
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should return 403 when request belongs to another user', async () => {
+      mockGdprRequestGetRequestById.mockRejectedValue(new Error('Unauthorized access') as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/gdpr/requests/req-other')
+        .expect(403);
+
+      expect(res.body.success).toBe(false);
+    });
+  });
+
+  // ─── GET /data-export/:id/download ────────────────────────────────────────
+  describe('GET /data-export/:id/download', () => {
+    it('should return 401 when not authenticated', async () => {
+      authShouldReject = true;
+      await request(app).get('/api/v1/users/gdpr/data-export/req-1/download').expect(401);
+    });
+
+    it('should return JSON file with Content-Disposition header', async () => {
+      const exportData = { user: { id: userId }, requests: [] };
+      mockGdprRequestGetExportData.mockResolvedValue(exportData as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/gdpr/data-export/req-1/download')
+        .expect(200);
+
+      expect(res.headers['content-disposition']).toContain('dreamscape-data-export.json');
+    });
+
+    it('should return 400 when export is not completed', async () => {
+      mockGdprRequestGetExportData.mockRejectedValue(
+        new Error('Export is not completed yet') as never
+      );
+
+      const res = await request(app)
+        .get('/api/v1/users/gdpr/data-export/req-1/download')
+        .expect(400);
+
+      expect(res.body.success).toBe(false);
+    });
+  });
+});

--- a/tests/DR-544-user-routes/unit/onboarding.routes.test.ts
+++ b/tests/DR-544-user-routes/unit/onboarding.routes.test.ts
@@ -1,0 +1,336 @@
+import request from 'supertest';
+import express, { Express } from 'express';
+import { jest, describe, it, expect, beforeAll, beforeEach, afterEach } from '@jest/globals';
+import jwt from 'jsonwebtoken';
+
+const JWT_SECRET = 'test-secret';
+process.env.JWT_SECRET = JWT_SECRET;
+
+// ── Prisma mock ───────────────────────────────────────────────────────────────
+const mockTravelOnboardingProfileFindUnique = jest.fn();
+const mockTravelOnboardingProfileCreate = jest.fn();
+const mockTravelOnboardingProfileUpdate = jest.fn();
+const mockTravelOnboardingProfileDelete = jest.fn();
+const mockUserFindUnique = jest.fn();
+const mockUserUpdate = jest.fn();
+const mockAnalyticsCreate = jest.fn();
+const mockTokenBlacklistFindUnique = jest.fn();
+
+jest.mock('@dreamscape/db', () => ({
+  prisma: {
+    travelOnboardingProfile: {
+      findUnique: mockTravelOnboardingProfileFindUnique,
+      create: mockTravelOnboardingProfileCreate,
+      update: mockTravelOnboardingProfileUpdate,
+      delete: mockTravelOnboardingProfileDelete,
+    },
+    user: {
+      findUnique: mockUserFindUnique,
+      update: mockUserUpdate,
+    },
+    analytics: {
+      create: mockAnalyticsCreate,
+    },
+    tokenBlacklist: {
+      findUnique: mockTokenBlacklistFindUnique,
+    },
+  },
+}));
+
+import onboardingRouter from '../../../../dreamscape-services/user/src/routes/onboarding';
+
+// ── Test data ─────────────────────────────────────────────────────────────────
+const userId = 'user-123';
+const validToken = jwt.sign({ userId, email: 'test@example.com', type: 'access' }, JWT_SECRET, { expiresIn: '7d' });
+
+const mockProfile = {
+  id: 'profile-1',
+  userId,
+  isCompleted: false,
+  completedSteps: [],
+  version: 1,
+  travelTypes: [],
+  accommodationTypes: [],
+  preferredDestinations: null,
+  globalBudgetRange: null,
+  budgetByCategory: null,
+  travelStyle: null,
+  comfortLevel: null,
+  accommodationLevel: null,
+  activityLevel: null,
+  riskTolerance: null,
+  budgetFlexibility: null,
+  dateFlexibility: null,
+  travelGroupTypes: [],
+  travelWithChildren: false,
+  childrenAges: [],
+  preferredSeasons: [],
+  weatherTolerances: null,
+  preferredTripDuration: null,
+  roomPreferences: null,
+  groupSize: null,
+  loyaltyPrograms: null,
+  paymentPreferences: [],
+  preferredAirlines: [],
+  cabinClassPreference: null,
+  transportModes: [],
+  transportBudgetShare: null,
+  activityTypes: [],
+  interestCategories: [],
+  dietaryRequirements: [],
+  accessibilityNeeds: [],
+  healthConsiderations: [],
+  culturalConsiderations: [],
+  languageBarriers: [],
+  experienceLevel: null,
+  culturalImmersion: null,
+  climatePreferences: [],
+  travelPurposes: [],
+  serviceLevel: null,
+  privacyPreference: null,
+  updatedAt: new Date(),
+};
+
+const mockUser = {
+  id: userId,
+  email: 'test@example.com',
+  onboardingCompleted: false,
+  onboardingCompletedAt: null,
+};
+
+describe('Onboarding Routes', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/v1/users/onboarding', onboardingRouter);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTokenBlacklistFindUnique.mockResolvedValue(null as never);
+    mockAnalyticsCreate.mockResolvedValue({} as never);
+    mockUserFindUnique.mockResolvedValue(mockUser as never);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // ─── GET / ────────────────────────────────────────────────────────────────
+  describe('GET /', () => {
+    it('should return 401 without token', async () => {
+      const res = await request(app)
+        .get('/api/v1/users/onboarding')
+        .expect(401);
+
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should return 404 when profile does not exist', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(null as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(404);
+
+      expect(res.body).toHaveProperty('error');
+    });
+
+    it('should return 200 with the onboarding profile', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(mockProfile as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.id).toBe('profile-1');
+    });
+  });
+
+  // ─── POST / ───────────────────────────────────────────────────────────────
+  describe('POST /', () => {
+    it('should return 401 without token', async () => {
+      await request(app).post('/api/v1/users/onboarding').expect(401);
+    });
+
+    it('should return 200 when profile is created successfully', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(null as never);
+      mockTravelOnboardingProfileCreate.mockResolvedValue(mockProfile as never);
+
+      const res = await request(app)
+        .post('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+    });
+
+    it('should return 409 when profile already exists', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(mockProfile as never);
+
+      const res = await request(app)
+        .post('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(409);
+
+      expect(res.body).toHaveProperty('error');
+    });
+  });
+
+  // ─── PUT /step ────────────────────────────────────────────────────────────
+  describe('PUT /step', () => {
+    it('should return 401 without token', async () => {
+      await request(app).put('/api/v1/users/onboarding/step').send({ step: 'destinations', data: {} }).expect(401);
+    });
+
+    it('should return 400 when step is missing', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({ data: {} })
+        .expect(400);
+
+      expect(res.body).toHaveProperty('error');
+    });
+
+    it('should return 400 when data is missing', async () => {
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({ step: 'destinations' })
+        .expect(400);
+
+      expect(res.body).toHaveProperty('error');
+    });
+
+    it('should return 200 when step is updated successfully', async () => {
+      const updatedProfile = { ...mockProfile, completedSteps: ['destinations'] };
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(mockProfile as never);
+      mockTravelOnboardingProfileUpdate.mockResolvedValue(updatedProfile as never);
+
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({ step: 'destinations', data: { regions: ['Europe'] } })
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+    });
+
+    it('should return 400 for invalid budget (min >= max)', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(mockProfile as never);
+
+      const res = await request(app)
+        .put('/api/v1/users/onboarding/step')
+        .set('Authorization', `Bearer ${validToken}`)
+        .send({ step: 'budget', data: { globalBudgetRange: { min: 1000, max: 500, currency: 'EUR' } } })
+        .expect(400);
+
+      expect(res.body).toHaveProperty('error');
+    });
+  });
+
+  // ─── GET /progress ────────────────────────────────────────────────────────
+  describe('GET /progress', () => {
+    it('should return 401 without token', async () => {
+      await request(app).get('/api/v1/users/onboarding/progress').expect(401);
+    });
+
+    it('should return 404 when profile does not exist', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(null as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/onboarding/progress')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(404);
+
+      expect(res.body).toHaveProperty('error');
+    });
+
+    it('should return 200 with progress data', async () => {
+      const profileWithUser = { ...mockProfile, user: { onboardingCompleted: false, onboardingCompletedAt: null } };
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(profileWithUser as never);
+
+      const res = await request(app)
+        .get('/api/v1/users/onboarding/progress')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('progressPercentage');
+    });
+  });
+
+  // ─── POST /complete ───────────────────────────────────────────────────────
+  describe('POST /complete', () => {
+    it('should return 401 without token', async () => {
+      await request(app).post('/api/v1/users/onboarding/complete').expect(401);
+    });
+
+    it('should return 400 when required steps are not completed', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(mockProfile as never);
+
+      const res = await request(app)
+        .post('/api/v1/users/onboarding/complete')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(400);
+
+      expect(res.body).toHaveProperty('error');
+    });
+
+    it('should return 200 when onboarding is completed successfully', async () => {
+      const completedProfile = {
+        ...mockProfile,
+        isCompleted: true,
+        completedSteps: ['destinations', 'budget', 'travel_types', 'accommodation', 'transport'],
+      };
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(completedProfile as never);
+      mockTravelOnboardingProfileUpdate.mockResolvedValue(completedProfile as never);
+      mockUserUpdate.mockResolvedValue({ ...mockUser, onboardingCompleted: true } as never);
+
+      const res = await request(app)
+        .post('/api/v1/users/onboarding/complete')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+    });
+  });
+
+  // ─── DELETE / ─────────────────────────────────────────────────────────────
+  describe('DELETE /', () => {
+    it('should return 401 without token', async () => {
+      await request(app).delete('/api/v1/users/onboarding').expect(401);
+    });
+
+    it('should return 200 when profile is deleted successfully', async () => {
+      mockTravelOnboardingProfileFindUnique.mockResolvedValue(mockProfile as never);
+      mockTravelOnboardingProfileDelete.mockResolvedValue(mockProfile as never);
+      mockUserUpdate.mockResolvedValue(mockUser as never);
+
+      const res = await request(app)
+        .delete('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+    });
+
+    it('should return 404 when profile does not exist', async () => {
+      const p2025Error = Object.assign(new Error('Not found'), { code: 'P2025' });
+      mockTravelOnboardingProfileDelete.mockRejectedValue(p2025Error as never);
+
+      const res = await request(app)
+        .delete('/api/v1/users/onboarding')
+        .set('Authorization', `Bearer ${validToken}`)
+        .expect(404);
+
+      expect(res.body).toHaveProperty('error');
+    });
+  });
+});

--- a/tests/DR-545-user-middleware/unit/auditLogger.test.ts
+++ b/tests/DR-545-user-middleware/unit/auditLogger.test.ts
@@ -1,0 +1,266 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { EventEmitter } from 'events';
+import { NextFunction } from 'express';
+
+// Mock Prisma
+const mockDataAccessLogCreate = jest.fn();
+jest.mock('@dreamscape/db', () => ({
+  prisma: {
+    dataAccessLog: {
+      create: mockDataAccessLogCreate,
+    },
+  },
+}));
+
+import { auditLogger } from '../../../../dreamscape-services/user/src/middleware/auditLogger';
+
+// Helper: create a mock response that extends EventEmitter
+const createMockRes = () => {
+  const res = new EventEmitter() as any;
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+// Helper: create an authenticated mock request
+const createAuthReq = (overrides: any = {}) => ({
+  user: { id: 'user-123', email: 'test@example.com' },
+  originalUrl: '/api/v1/users/profile',
+  method: 'GET',
+  ip: '127.0.0.1',
+  socket: { remoteAddress: '127.0.0.1' },
+  headers: { 'user-agent': 'jest-test-agent' },
+  ...overrides,
+});
+
+// Helper: trigger res.finish and wait for async listener
+const triggerFinish = async (res: any) => {
+  res.emit('finish');
+  await new Promise(resolve => setTimeout(resolve, 20));
+};
+
+describe('auditLogger middleware', () => {
+  let mockNext: jest.Mock;
+
+  beforeEach(() => {
+    mockNext = jest.fn();
+    mockDataAccessLogCreate.mockResolvedValue({} as never);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('next() call behaviour', () => {
+    it('should call next() immediately for audited routes', () => {
+      const req = createAuthReq();
+      const res = createMockRes();
+
+      auditLogger(req, res, mockNext as NextFunction);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call next() immediately for non-audited routes', () => {
+      const req = createAuthReq({ originalUrl: '/api/v1/health' });
+      const res = createMockRes();
+
+      auditLogger(req, res, mockNext as NextFunction);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('audit log creation', () => {
+    it('should create a log entry for GET /api/v1/users/profile', async () => {
+      const req = createAuthReq({ originalUrl: '/api/v1/users/profile', method: 'GET' });
+      const res = createMockRes();
+
+      auditLogger(req, res, mockNext as NextFunction);
+      await triggerFinish(res);
+
+      expect(mockDataAccessLogCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          userId: 'user-123',
+          accessorId: 'user-123',
+          accessorType: 'user',
+          action: 'READ',
+          resource: 'UserProfile',
+          ipAddress: '127.0.0.1',
+          userAgent: 'jest-test-agent',
+          endpoint: '/api/v1/users/profile',
+          method: 'GET',
+        }),
+      });
+    });
+
+    it('should create a log entry for /api/v1/users/favorites', async () => {
+      const req = createAuthReq({ originalUrl: '/api/v1/users/favorites', method: 'GET' });
+      const res = createMockRes();
+
+      auditLogger(req, res, mockNext as NextFunction);
+      await triggerFinish(res);
+
+      expect(mockDataAccessLogCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({ resource: 'Favorite', action: 'READ' }),
+      });
+    });
+
+    it('should create a log entry for /api/v1/users/history', async () => {
+      const req = createAuthReq({ originalUrl: '/api/v1/users/history', method: 'DELETE' });
+      const res = createMockRes();
+
+      auditLogger(req, res, mockNext as NextFunction);
+      await triggerFinish(res);
+
+      expect(mockDataAccessLogCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({ resource: 'UserHistory', action: 'DELETE' }),
+      });
+    });
+
+    it('should create a log entry for /api/v1/users/onboarding', async () => {
+      const req = createAuthReq({ originalUrl: '/api/v1/users/onboarding', method: 'PUT' });
+      const res = createMockRes();
+
+      auditLogger(req, res, mockNext as NextFunction);
+      await triggerFinish(res);
+
+      expect(mockDataAccessLogCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({ resource: 'TravelOnboardingProfile', action: 'UPDATE' }),
+      });
+    });
+
+    it('should create a log entry for /api/v1/users/gdpr', async () => {
+      const req = createAuthReq({ originalUrl: '/api/v1/users/gdpr/consent', method: 'POST' });
+      const res = createMockRes();
+
+      auditLogger(req, res, mockNext as NextFunction);
+      await triggerFinish(res);
+
+      expect(mockDataAccessLogCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({ resource: 'GdprData', action: 'CREATE' }),
+      });
+    });
+  });
+
+  describe('action mapping', () => {
+    const actions: Array<[string, string]> = [
+      ['GET', 'READ'],
+      ['POST', 'CREATE'],
+      ['PUT', 'UPDATE'],
+      ['PATCH', 'UPDATE'],
+      ['DELETE', 'DELETE'],
+    ];
+
+    for (const [method, expectedAction] of actions) {
+      it(`should map ${method} to ${expectedAction}`, async () => {
+        const req = createAuthReq({ method, originalUrl: '/api/v1/users/profile' });
+        const res = createMockRes();
+
+        auditLogger(req, res, mockNext as NextFunction);
+        await triggerFinish(res);
+
+        expect(mockDataAccessLogCreate).toHaveBeenCalledWith({
+          data: expect.objectContaining({ action: expectedAction }),
+        });
+      });
+    }
+
+    it('should fall back to READ for unknown HTTP methods (e.g. OPTIONS)', async () => {
+      const req = createAuthReq({ method: 'OPTIONS', originalUrl: '/api/v1/users/profile' });
+      const res = createMockRes();
+
+      auditLogger(req, res, mockNext as NextFunction);
+      await triggerFinish(res);
+
+      expect(mockDataAccessLogCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({ action: 'READ' }),
+      });
+    });
+  });
+
+  describe('no log for unauthenticated or non-audited requests', () => {
+    it('should NOT create a log when req.user is absent', async () => {
+      const req = { ...createAuthReq(), user: undefined };
+      const res = createMockRes();
+
+      auditLogger(req, res, mockNext as NextFunction);
+      await triggerFinish(res);
+
+      expect(mockDataAccessLogCreate).not.toHaveBeenCalled();
+    });
+
+    it('should NOT create a log for a non-audited route', async () => {
+      const req = createAuthReq({ originalUrl: '/api/v1/health' });
+      const res = createMockRes();
+
+      auditLogger(req, res, mockNext as NextFunction);
+      await triggerFinish(res);
+
+      expect(mockDataAccessLogCreate).not.toHaveBeenCalled();
+    });
+
+    it('should NOT create a log for /api/v1/users/admin', async () => {
+      const req = createAuthReq({ originalUrl: '/api/v1/users/admin' });
+      const res = createMockRes();
+
+      auditLogger(req, res, mockNext as NextFunction);
+      await triggerFinish(res);
+
+      expect(mockDataAccessLogCreate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fallback values', () => {
+    it('should use socket.remoteAddress when req.ip is undefined', async () => {
+      const req = { ...createAuthReq(), ip: undefined, socket: { remoteAddress: '10.0.0.1' } };
+      const res = createMockRes();
+
+      auditLogger(req, res, mockNext as NextFunction);
+      await triggerFinish(res);
+
+      expect(mockDataAccessLogCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({ ipAddress: '10.0.0.1' }),
+      });
+    });
+
+    it('should use "unknown" when both ip and socket.remoteAddress are absent', async () => {
+      const req = { ...createAuthReq(), ip: undefined, socket: {} };
+      const res = createMockRes();
+
+      auditLogger(req, res, mockNext as NextFunction);
+      await triggerFinish(res);
+
+      expect(mockDataAccessLogCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({ ipAddress: 'unknown' }),
+      });
+    });
+
+    it('should use "unknown" when user-agent header is absent', async () => {
+      const req = { ...createAuthReq(), headers: {} };
+      const res = createMockRes();
+
+      auditLogger(req, res, mockNext as NextFunction);
+      await triggerFinish(res);
+
+      expect(mockDataAccessLogCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({ userAgent: 'unknown' }),
+      });
+    });
+  });
+
+  describe('silent failure on prisma error', () => {
+    it('should NOT throw when prisma.dataAccessLog.create fails', async () => {
+      mockDataAccessLogCreate.mockRejectedValue(new Error('DB error') as never);
+      const req = createAuthReq();
+      const res = createMockRes();
+
+      auditLogger(req, res, mockNext as NextFunction);
+
+      // Should not throw
+      await expect(triggerFinish(res)).resolves.not.toThrow();
+      expect(mockNext).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/DR-545-user-middleware/unit/errorHandler.test.ts
+++ b/tests/DR-545-user-middleware/unit/errorHandler.test.ts
@@ -1,0 +1,150 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { Request, Response, NextFunction } from 'express';
+import { errorHandler, notFoundHandler, ApiError } from '../../../../dreamscape-services/user/src/middleware/errorHandler';
+
+describe('errorHandler middleware', () => {
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let mockNext: jest.Mock;
+  let statusMock: jest.Mock;
+  let jsonMock: jest.Mock;
+
+  beforeEach(() => {
+    jsonMock = jest.fn().mockReturnThis() as jest.Mock;
+    statusMock = jest.fn().mockReturnValue({ json: jsonMock }) as jest.Mock;
+    mockRes = { status: statusMock, json: jsonMock };
+    mockReq = { url: '/api/v1/users/test', method: 'GET', originalUrl: '/api/v1/users/test' };
+    mockNext = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('errorHandler', () => {
+    it('should return 500 by default when no statusCode is set', () => {
+      const err: ApiError = new Error('Something went wrong');
+
+      errorHandler(err, mockReq as Request, mockRes as Response, mockNext as NextFunction);
+
+      expect(statusMock).toHaveBeenCalledWith(500);
+      const jsonCall = (statusMock as jest.Mock).mock.results[0].value.json;
+      expect(jsonCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({
+            message: 'Something went wrong',
+            status: 500,
+          }),
+        })
+      );
+    });
+
+    it('should use the statusCode from the error when provided', () => {
+      const err: ApiError = new Error('Not Found');
+      err.statusCode = 404;
+
+      errorHandler(err, mockReq as Request, mockRes as Response, mockNext as NextFunction);
+
+      expect(statusMock).toHaveBeenCalledWith(404);
+    });
+
+    it('should handle 400 Bad Request', () => {
+      const err: ApiError = new Error('Bad Request');
+      err.statusCode = 400;
+
+      errorHandler(err, mockReq as Request, mockRes as Response, mockNext as NextFunction);
+
+      expect(statusMock).toHaveBeenCalledWith(400);
+      const jsonCall = (statusMock as jest.Mock).mock.results[0].value.json;
+      expect(jsonCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({ status: 400, message: 'Bad Request' }),
+        })
+      );
+    });
+
+    it('should handle 401 Unauthorized', () => {
+      const err: ApiError = new Error('Unauthorized');
+      err.statusCode = 401;
+
+      errorHandler(err, mockReq as Request, mockRes as Response, mockNext as NextFunction);
+
+      expect(statusMock).toHaveBeenCalledWith(401);
+    });
+
+    it('should handle 403 Forbidden', () => {
+      const err: ApiError = new Error('Forbidden');
+      err.statusCode = 403;
+
+      errorHandler(err, mockReq as Request, mockRes as Response, mockNext as NextFunction);
+
+      expect(statusMock).toHaveBeenCalledWith(403);
+    });
+
+    it('should use default message when err.message is empty', () => {
+      const err: ApiError = new Error('');
+      err.statusCode = 500;
+
+      errorHandler(err, mockReq as Request, mockRes as Response, mockNext as NextFunction);
+
+      const jsonCall = (statusMock as jest.Mock).mock.results[0].value.json;
+      expect(jsonCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({ message: 'Internal Server Error' }),
+        })
+      );
+    });
+
+    it('should include timestamp and path in the response', () => {
+      const err: ApiError = new Error('Error');
+
+      errorHandler(err, mockReq as Request, mockRes as Response, mockNext as NextFunction);
+
+      const jsonCall = (statusMock as jest.Mock).mock.results[0].value.json;
+      const callArg = jsonCall.mock.calls[0][0] as any;
+      expect(callArg.error.timestamp).toBeDefined();
+      expect(callArg.error.path).toBe('/api/v1/users/test');
+    });
+
+    it('should include path from req.url', () => {
+      mockReq.url = '/api/v1/users/profile';
+      const err: ApiError = new Error('Error');
+
+      errorHandler(err, mockReq as Request, mockRes as Response, mockNext as NextFunction);
+
+      const jsonCall = (statusMock as jest.Mock).mock.results[0].value.json;
+      const callArg = jsonCall.mock.calls[0][0] as any;
+      expect(callArg.error.path).toBe('/api/v1/users/profile');
+    });
+  });
+
+  describe('notFoundHandler', () => {
+    it('should return 404 with route not found message', () => {
+      mockReq.originalUrl = '/api/v1/unknown';
+
+      notFoundHandler(mockReq as Request, mockRes as Response);
+
+      expect(statusMock).toHaveBeenCalledWith(404);
+      const jsonCall = (statusMock as jest.Mock).mock.results[0].value.json;
+      expect(jsonCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({
+            message: 'Route /api/v1/unknown not found',
+            status: 404,
+          }),
+        })
+      );
+    });
+
+    it('should include timestamp and path for 404', () => {
+      mockReq.originalUrl = '/api/v1/missing';
+
+      notFoundHandler(mockReq as Request, mockRes as Response);
+
+      const jsonCall = (statusMock as jest.Mock).mock.results[0].value.json;
+      const callArg = jsonCall.mock.calls[0][0] as any;
+      expect(callArg.error.timestamp).toBeDefined();
+      expect(callArg.error.path).toBe('/api/v1/missing');
+    });
+  });
+});

--- a/tests/DR-545-user-middleware/unit/rateLimiter.test.ts
+++ b/tests/DR-545-user-middleware/unit/rateLimiter.test.ts
@@ -1,0 +1,118 @@
+import { jest, describe, it, expect, beforeAll } from '@jest/globals';
+
+jest.mock('express-rate-limit', () => {
+  return jest.fn().mockImplementation((_options: any) => {
+    return (_req: any, _res: any, next: any) => next();
+  });
+});
+
+import rateLimit from 'express-rate-limit';
+import { apiLimiter, searchLimiter, favoritesCheckLimiter } from '../../../../dreamscape-services/user/src/middleware/rateLimiter';
+
+describe('Rate Limiter Middleware', () => {
+  const mockRateLimit = rateLimit as unknown as jest.Mock;
+
+  // Capture options before the global afterEach (jest.setup.js) clears mock.calls
+  let apiOpts: any;
+  let searchOpts: any;
+  let favoritesOpts: any;
+
+  beforeAll(() => {
+    apiOpts = mockRateLimit.mock.calls[0]?.[0];
+    searchOpts = mockRateLimit.mock.calls[1]?.[0];
+    favoritesOpts = mockRateLimit.mock.calls[2]?.[0];
+  });
+
+  describe('apiLimiter', () => {
+    it('should be defined', () => {
+      expect(apiLimiter).toBeDefined();
+    });
+
+    it('should be configured with 15 minute window', () => {
+      expect(apiOpts.windowMs).toBe(15 * 60 * 1000);
+    });
+
+    it('should allow max 100 requests per window', () => {
+      expect(apiOpts.max).toBe(100);
+    });
+
+    it('should have standard headers enabled', () => {
+      expect(apiOpts.standardHeaders).toBe(true);
+    });
+
+    it('should have legacy headers disabled', () => {
+      expect(apiOpts.legacyHeaders).toBe(false);
+    });
+
+    it('should have a custom error message', () => {
+      expect(apiOpts.message).toEqual(
+        expect.objectContaining({
+          error: expect.any(String),
+          retryAfter: '15 minutes',
+        })
+      );
+    });
+  });
+
+  describe('searchLimiter', () => {
+    it('should be defined', () => {
+      expect(searchLimiter).toBeDefined();
+    });
+
+    it('should be configured with 1 minute window', () => {
+      expect(searchOpts.windowMs).toBe(1 * 60 * 1000);
+    });
+
+    it('should allow max 20 requests per window', () => {
+      expect(searchOpts.max).toBe(20);
+    });
+
+    it('should have standard headers enabled', () => {
+      expect(searchOpts.standardHeaders).toBe(true);
+    });
+
+    it('should have legacy headers disabled', () => {
+      expect(searchOpts.legacyHeaders).toBe(false);
+    });
+
+    it('should have a custom error message with retryAfter 1 minute', () => {
+      expect(searchOpts.message).toEqual(
+        expect.objectContaining({
+          error: expect.any(String),
+          retryAfter: '1 minute',
+        })
+      );
+    });
+  });
+
+  describe('favoritesCheckLimiter', () => {
+    it('should be defined', () => {
+      expect(favoritesCheckLimiter).toBeDefined();
+    });
+
+    it('should be configured with 1 minute window', () => {
+      expect(favoritesOpts.windowMs).toBe(1 * 60 * 1000);
+    });
+
+    it('should allow max 50 requests per window', () => {
+      expect(favoritesOpts.max).toBe(50);
+    });
+
+    it('should have standard headers enabled', () => {
+      expect(favoritesOpts.standardHeaders).toBe(true);
+    });
+
+    it('should have legacy headers disabled', () => {
+      expect(favoritesOpts.legacyHeaders).toBe(false);
+    });
+
+    it('should have a custom error message with retryAfter 1 minute', () => {
+      expect(favoritesOpts.message).toEqual(
+        expect.objectContaining({
+          error: expect.any(String),
+          retryAfter: '1 minute',
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **DR-542** — `onboardingController` & `aiIntegrationController` unit tests (71 tests)
- **DR-543** — GDPR services unit tests: `ConsentService`, `GdprRequestService`, `PrivacyPolicyService`, `AuditLogService` (67 tests)
- **DR-544** — Route unit tests: GDPR, onboarding, AI integration, activities (55 tests)
- **DR-545** — Middleware unit tests: `errorHandler`, `rateLimiter`, `auditLogger` (64 tests)
- `jest.config.js` — adds `express-rate-limit` `moduleNameMapper` for consistent mock interception

## Coverage (257 tests · 13 suites · all passing)

| Category | % Stmts | % Branch | % Funcs | % Lines |
|----------|---------|----------|---------|---------|
| **Overall** | 98.73 | 91.45 | 100 | 98.64 |
| Middleware | 100 | 100 | 100 | 100 |
| Services | 100 | 98.18 | 100 | 100 |
| Routes | 97.56 | 89.47 | 100 | 97.46 |
| Controllers | 98.41 | 90.56 | 100 | 98.25 |

Remaining uncovered lines are structurally unreachable dead code (duplicate switch case, Express always-populated route params).

## Test plan

- [x] All 257 tests pass locally (`npx jest --testPathPattern="DR-54[2-5]"`)
- [x] Coverage measured via cross-rootDir Jest config
- [x] No changes to source files — tests only

🤖 Generated with [Claude Code](https://claude.com/claude-code)