### PR TITLE
feat(tests): add Jest configuration and unit tests for DR-538-US-TEST…

### DIFF
--- a/__mocks__/redis.ts
+++ b/__mocks__/redis.ts
@@ -1,0 +1,27 @@
+/**
+ * Mock for @config/redis singleton - DR-538-US-TEST-002
+ */
+
+export const mockRawClient = {
+  keys: jest.fn(),
+  del: jest.fn(),
+  sAdd: jest.fn(),
+  sRem: jest.fn(),
+  sMembers: jest.fn(),
+  sendCommand: jest.fn(),
+};
+
+const mockRedisClient = {
+  get: jest.fn(),
+  set: jest.fn(),
+  del: jest.fn(),
+  exists: jest.fn(),
+  expire: jest.fn(),
+  ttl: jest.fn(),
+  isReady: jest.fn().mockReturnValue(true),
+  getClient: jest.fn().mockReturnValue(mockRawClient),
+  connect: jest.fn(),
+  disconnect: jest.fn(),
+};
+
+export default mockRedisClient;

--- a/jest.config.test002.js
+++ b/jest.config.test002.js
@@ -1,0 +1,56 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  testEnvironment: 'node',
+  rootDir: '../',
+
+  roots: [
+    '<rootDir>/dreamscape-tests/tests/DR-538-US-TEST-002',
+    '<rootDir>/dreamscape-services/auth/src/middleware',
+  ],
+  testMatch: ['**/DR-538-US-TEST-002/**/*.test.ts'],
+
+  moduleNameMapper: {
+    '^@types$': '<rootDir>/dreamscape-services/auth/src/types/index.ts',
+    '^@dreamscape/db$': '<rootDir>/dreamscape-tests/__mocks__/db.ts',
+    '^@config/redis$': '<rootDir>/dreamscape-tests/__mocks__/redis.ts',
+    '^jsonwebtoken$': '<rootDir>/dreamscape-services/auth/node_modules/jsonwebtoken',
+    '^bcryptjs$': '<rootDir>/dreamscape-services/auth/node_modules/bcryptjs',
+    '^express-rate-limit$': '<rootDir>/dreamscape-services/auth/node_modules/express-rate-limit',
+    '^rate-limit-redis$': '<rootDir>/dreamscape-services/auth/node_modules/rate-limit-redis',
+  },
+
+  setupFilesAfterEnv: ['<rootDir>/dreamscape-tests/jest.setup.js'],
+
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  transform: {
+    '^.+\\.ts$': ['<rootDir>/dreamscape-tests/node_modules/ts-jest', {
+      diagnostics: false,
+      tsconfig: {
+        module: 'commonjs',
+        esModuleInterop: true,
+        allowSyntheticDefaultImports: true,
+        strict: false,
+        paths: {
+          '@config/redis': ['<rootDir>/dreamscape-tests/__mocks__/redis.ts'],
+        },
+      },
+    }],
+  },
+
+  collectCoverageFrom: [
+    '<rootDir>/dreamscape-services/auth/src/middleware/auth.ts',
+    '<rootDir>/dreamscape-services/auth/src/middleware/errorHandler.ts',
+    '<rootDir>/dreamscape-services/auth/src/middleware/rateLimiter.ts',
+    '<rootDir>/dreamscape-services/auth/src/middleware/cache.ts',
+    '<rootDir>/dreamscape-services/auth/src/middleware/sessionManager.ts',
+  ],
+  coverageDirectory: '<rootDir>/dreamscape-tests/coverage/test002',
+  coverageThreshold: {
+    global: { branches: 80, functions: 80, lines: 80, statements: 80 },
+  },
+
+  // clearMocks only (NOT resetMocks) — rateLimiter.ts captures Redis state at module load time
+  clearMocks: true,
+  testTimeout: 10000,
+  verbose: true,
+};

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "test:health:realdb:verbose": "jest --config=jest.config.realdb.js --verbose",
     "test:dr538": "jest --config=jest.config.auth-unit.js --verbose",
     "test:dr538:coverage": "jest --config=jest.config.auth-unit.js --coverage",
+    "test:test002": "jest --config=jest.config.test002.js --verbose",
+    "test:test002:coverage": "jest --config=jest.config.test002.js --coverage",
     "test:performance": "npm run test:performance:api && npm run test:performance:frontend",
     "test:performance:api": "echo 'API performance tests - to be implemented'",
     "test:performance:frontend": "echo 'Frontend performance tests - to be implemented'",

--- a/tests/DR-538-US-TEST-002/unit/auth.test.ts
+++ b/tests/DR-538-US-TEST-002/unit/auth.test.ts
@@ -1,0 +1,331 @@
+import { prisma } from '@dreamscape/db';
+import jwt from 'jsonwebtoken';
+import {
+  authenticateToken,
+  optionalAuth,
+  authenticateRefreshToken,
+  AuthRequest,
+} from '../../.././../dreamscape-services/auth/src/middleware/auth';
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function makeReq(overrides: Partial<AuthRequest> = {}): AuthRequest {
+  return {
+    headers: {},
+    cookies: {},
+    body: {},
+    ...overrides,
+  } as AuthRequest;
+}
+
+function makeRes() {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+const JWT_SECRET = 'test-secret';
+const JWT_REFRESH_SECRET = 'test-refresh-secret';
+
+beforeEach(() => {
+  process.env.JWT_SECRET = JWT_SECRET;
+  process.env.JWT_REFRESH_SECRET = JWT_REFRESH_SECRET;
+});
+
+function signAccess(payload: object = {}) {
+  return jwt.sign({ userId: 'u1', email: 'a@b.com', type: 'access', ...payload }, JWT_SECRET, { expiresIn: '1h' });
+}
+function signRefresh(payload: object = {}) {
+  return jwt.sign({ userId: 'u1', email: 'a@b.com', type: 'refresh', ...payload }, JWT_REFRESH_SECRET, { expiresIn: '7d' });
+}
+
+// ─── authenticateToken ───────────────────────────────────────────────────────
+
+describe('authenticateToken', () => {
+  it('returns 401 when no Authorization header', async () => {
+    const req = makeReq({ headers: {} });
+    const res = makeRes();
+    const next = jest.fn();
+    await authenticateToken(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'TOKEN_MISSING' }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when token is blacklisted', async () => {
+    const token = signAccess();
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockPrisma.tokenBlacklist.findUnique as jest.Mock).mockResolvedValue({ token });
+    await authenticateToken(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'TOKEN_REVOKED' }));
+  });
+
+  it('returns 500 when JWT_SECRET is missing', async () => {
+    delete process.env.JWT_SECRET;
+    const token = 'any.token.here';
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockPrisma.tokenBlacklist.findUnique as jest.Mock).mockResolvedValue(null);
+    await authenticateToken(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+  it('returns 401 when token type is not access', async () => {
+    const token = signRefresh();
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockPrisma.tokenBlacklist.findUnique as jest.Mock).mockResolvedValue(null);
+    // JWT_REFRESH_SECRET !== JWT_SECRET, so jwt.verify with JWT_SECRET will throw
+    await authenticateToken(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('returns 401 when token type field is wrong but signed with access secret', async () => {
+    const token = jwt.sign({ userId: 'u1', email: 'a@b.com', type: 'refresh' }, JWT_SECRET, { expiresIn: '1h' });
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockPrisma.tokenBlacklist.findUnique as jest.Mock).mockResolvedValue(null);
+    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+    await authenticateToken(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_TOKEN_TYPE' }));
+  });
+
+  it('returns 401 when user not found', async () => {
+    const token = signAccess();
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockPrisma.tokenBlacklist.findUnique as jest.Mock).mockResolvedValue(null);
+    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+    await authenticateToken(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'USER_INACTIVE' }));
+  });
+
+  it('calls next and sets req.user when valid', async () => {
+    const token = signAccess();
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockPrisma.tokenBlacklist.findUnique as jest.Mock).mockResolvedValue(null);
+    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'u1', email: 'a@b.com' });
+    await authenticateToken(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toEqual({ id: 'u1', email: 'a@b.com' });
+  });
+
+  it('returns 401 with TOKEN_EXPIRED when token is expired', async () => {
+    const token = jwt.sign({ userId: 'u1', email: 'a@b.com', type: 'access' }, JWT_SECRET, { expiresIn: -1 });
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockPrisma.tokenBlacklist.findUnique as jest.Mock).mockResolvedValue(null);
+    await authenticateToken(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'TOKEN_EXPIRED' }));
+  });
+
+  it('returns 401 with INVALID_TOKEN when token is malformed', async () => {
+    const req = makeReq({ headers: { authorization: 'Bearer not.a.real.jwt' } });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockPrisma.tokenBlacklist.findUnique as jest.Mock).mockResolvedValue(null);
+    await authenticateToken(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_TOKEN' }));
+  });
+
+  it('returns 500 when an unexpected error occurs', async () => {
+    const token = signAccess();
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockPrisma.tokenBlacklist.findUnique as jest.Mock).mockRejectedValue(new Error('DB down'));
+    await authenticateToken(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});
+
+// ─── optionalAuth ─────────────────────────────────────────────────────────────
+
+describe('optionalAuth', () => {
+  it('calls next immediately when no token provided', async () => {
+    const req = makeReq({ headers: {} });
+    const res = makeRes();
+    const next = jest.fn();
+    await optionalAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toBeUndefined();
+  });
+
+  it('calls next without setting user when token is blacklisted', async () => {
+    const token = signAccess();
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockPrisma.tokenBlacklist.findUnique as jest.Mock).mockResolvedValue({ token });
+    await optionalAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toBeUndefined();
+  });
+
+  it('calls next without user when JWT_SECRET missing', async () => {
+    delete process.env.JWT_SECRET;
+    const token = signAccess();
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockPrisma.tokenBlacklist.findUnique as jest.Mock).mockResolvedValue(null);
+    await optionalAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toBeUndefined();
+  });
+
+  it('sets req.user when valid access token', async () => {
+    const token = signAccess();
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockPrisma.tokenBlacklist.findUnique as jest.Mock).mockResolvedValue(null);
+    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'u1', email: 'a@b.com' });
+    await optionalAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toEqual({ id: 'u1', email: 'a@b.com' });
+  });
+
+  it('calls next without user when user not found', async () => {
+    const token = signAccess();
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockPrisma.tokenBlacklist.findUnique as jest.Mock).mockResolvedValue(null);
+    (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+    await optionalAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toBeUndefined();
+  });
+
+  it('calls next on token error (error catch → next)', async () => {
+    const req = makeReq({ headers: { authorization: 'Bearer bad.token' } });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockPrisma.tokenBlacklist.findUnique as jest.Mock).mockResolvedValue(null);
+    await optionalAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+});
+
+// ─── authenticateRefreshToken ─────────────────────────────────────────────────
+
+describe('authenticateRefreshToken', () => {
+  it('returns 401 when no refresh token', async () => {
+    const req = makeReq({ cookies: {}, body: {} });
+    const res = makeRes();
+    const next = jest.fn();
+    await authenticateRefreshToken(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'REFRESH_TOKEN_MISSING' }));
+  });
+
+  it('returns 500 when JWT secret not configured', async () => {
+    delete process.env.JWT_SECRET;
+    delete process.env.JWT_REFRESH_SECRET;
+    const req = makeReq({ cookies: {}, body: { refreshToken: 'any' } });
+    const res = makeRes();
+    const next = jest.fn();
+    await authenticateRefreshToken(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+  it('returns 401 when token type is not refresh', async () => {
+    const token = jwt.sign({ userId: 'u1', email: 'a@b.com', type: 'access' }, JWT_REFRESH_SECRET, { expiresIn: '1h' });
+    const req = makeReq({ cookies: { refreshToken: token }, body: {} });
+    const res = makeRes();
+    const next = jest.fn();
+    await authenticateRefreshToken(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_REFRESH_TOKEN' }));
+  });
+
+  it('returns 401 when session not found in DB', async () => {
+    const token = signRefresh();
+    const req = makeReq({ cookies: { refreshToken: token }, body: {} });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockPrisma.session.findFirst as jest.Mock).mockResolvedValue(null);
+    await authenticateRefreshToken(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('calls next and sets req.user when valid', async () => {
+    const token = signRefresh();
+    const req = makeReq({ cookies: { refreshToken: token }, body: {} });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockPrisma.session.findFirst as jest.Mock).mockResolvedValue({
+      id: 's1',
+      user: { id: 'u1', email: 'a@b.com' }
+    });
+    await authenticateRefreshToken(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toEqual({ id: 'u1', email: 'a@b.com' });
+  });
+
+  it('picks refresh token from body when cookie missing', async () => {
+    const token = signRefresh();
+    const req = makeReq({ cookies: {}, body: { refreshToken: token } });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockPrisma.session.findFirst as jest.Mock).mockResolvedValue({
+      id: 's1',
+      user: { id: 'u1', email: 'a@b.com' }
+    });
+    await authenticateRefreshToken(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('returns 401 with REFRESH_TOKEN_EXPIRED on expired token', async () => {
+    const token = jwt.sign({ userId: 'u1', email: 'a@b.com', type: 'refresh' }, JWT_REFRESH_SECRET, { expiresIn: -1 });
+    const req = makeReq({ cookies: { refreshToken: token }, body: {} });
+    const res = makeRes();
+    const next = jest.fn();
+    await authenticateRefreshToken(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'REFRESH_TOKEN_EXPIRED' }));
+  });
+
+  it('returns 401 with INVALID_REFRESH_TOKEN on malformed token', async () => {
+    const req = makeReq({ cookies: { refreshToken: 'bad.token' }, body: {} });
+    const res = makeRes();
+    const next = jest.fn();
+    await authenticateRefreshToken(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_REFRESH_TOKEN' }));
+  });
+
+  it('returns 500 on unexpected DB error', async () => {
+    const token = signRefresh();
+    const req = makeReq({ cookies: { refreshToken: token }, body: {} });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockPrisma.session.findFirst as jest.Mock).mockRejectedValue(new Error('DB down'));
+    await authenticateRefreshToken(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});

--- a/tests/DR-538-US-TEST-002/unit/cache.test.ts
+++ b/tests/DR-538-US-TEST-002/unit/cache.test.ts
@@ -1,0 +1,360 @@
+import { Request, Response, NextFunction } from 'express';
+import mockRedisClient, { mockRawClient } from '../../../../dreamscape-tests/__mocks__/redis';
+import {
+  cacheMiddleware,
+  CacheInvalidator,
+  cache,
+} from '../../../../dreamscape-services/auth/src/middleware/cache';
+
+const mockRedis = mockRedisClient as jest.Mocked<typeof mockRedisClient>;
+const mockRaw = mockRawClient as jest.Mocked<typeof mockRawClient>;
+
+function makeReq(overrides: Partial<Request> = {}): Request {
+  return {
+    method: 'GET',
+    path: '/api/profile',
+    query: {},
+    get: jest.fn().mockReturnValue(undefined),
+    body: {},
+    ...overrides,
+  } as unknown as Request;
+}
+
+function makeRes() {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.set = jest.fn().mockReturnValue(res);
+  res.get = jest.fn().mockReturnValue('application/json');
+  res.statusCode = 200;
+  return res;
+}
+
+// ─── cacheMiddleware ──────────────────────────────────────────────────────────
+
+describe('cacheMiddleware', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    (mockRedis.isReady as jest.Mock).mockReturnValue(true);
+    (mockRedis.get as jest.Mock).mockResolvedValue(null);
+    (mockRedis.set as jest.Mock).mockResolvedValue(true);
+  });
+
+  it('calls next immediately for non-GET requests', async () => {
+    const middleware = cacheMiddleware();
+    const req = makeReq({ method: 'POST' });
+    const res = makeRes();
+    const next = jest.fn();
+    await middleware(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(mockRedis.get).not.toHaveBeenCalled();
+  });
+
+  it('calls next immediately when Redis is not ready', async () => {
+    (mockRedis.isReady as jest.Mock).mockReturnValue(false);
+    const middleware = cacheMiddleware();
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+    await middleware(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(mockRedis.get).not.toHaveBeenCalled();
+  });
+
+  it('returns cached response on cache HIT and sets X-Cache: HIT', async () => {
+    const cachedData = JSON.stringify({
+      status: 200,
+      body: { user: 'data' },
+      headers: { 'content-type': 'application/json' },
+    });
+    (mockRedis.get as jest.Mock).mockResolvedValue(cachedData);
+
+    const middleware = cacheMiddleware();
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.set).toHaveBeenCalledWith('X-Cache', 'HIT');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ user: 'data' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('on cache HIT restores cached headers', async () => {
+    const cachedData = JSON.stringify({
+      status: 200,
+      body: {},
+      headers: { 'content-type': 'application/json', 'x-custom': 'value' },
+    });
+    (mockRedis.get as jest.Mock).mockResolvedValue(cachedData);
+
+    const middleware = cacheMiddleware();
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.set).toHaveBeenCalledWith('x-custom', 'value');
+  });
+
+  it('on cache HIT uses status 200 as default when cached.status is missing', async () => {
+    const cachedData = JSON.stringify({ body: { ok: true } });
+    (mockRedis.get as jest.Mock).mockResolvedValue(cachedData);
+
+    const middleware = cacheMiddleware();
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('sets X-Cache: MISS on cache miss and calls next', async () => {
+    const middleware = cacheMiddleware();
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.set).toHaveBeenCalledWith('X-Cache', 'MISS');
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('on cache MISS, res.json is overridden and stores response in Redis', async () => {
+    const middleware = cacheMiddleware({ ttl: 120 });
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    // Call the overridden res.json with a body
+    res.json({ result: 'ok' });
+
+    // Wait for async Redis.set call
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      expect.stringContaining('cache:'),
+      expect.stringContaining('"result":"ok"'),
+      120
+    );
+  });
+
+  it('handles Redis.set rejection in the async .catch (does not throw)', async () => {
+    (mockRedis.set as jest.Mock).mockRejectedValue(new Error('set fail'));
+    const middleware = cacheMiddleware({ ttl: 60 });
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+    res.json({ ok: true });
+
+    // Wait for the async .catch to execute — should not throw
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('does not cache non-2xx responses', async () => {
+    const middleware = cacheMiddleware();
+    const req = makeReq();
+    const res = makeRes();
+    res.statusCode = 404;
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+    res.json({ error: 'not found' });
+
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(mockRedis.set).not.toHaveBeenCalled();
+  });
+
+  it('calls next on Redis error', async () => {
+    (mockRedis.get as jest.Mock).mockRejectedValue(new Error('Redis error'));
+    const middleware = cacheMiddleware();
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('includes query params in cache key', async () => {
+    const middleware = cacheMiddleware();
+    const req = makeReq({
+      query: { page: '2', limit: '10' } as any,
+    });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    const cacheKeyCall = (mockRedis.get as jest.Mock).mock.calls[0][0];
+    expect(cacheKeyCall).toContain('page');
+  });
+
+  it('excludes query params from cache key when excludeQuery=true', async () => {
+    const middleware = cacheMiddleware({ excludeQuery: true });
+    const req1 = makeReq({ query: { page: '1' } as any });
+    const req2 = makeReq({ query: { page: '2' } as any });
+    const res = makeRes();
+
+    await middleware(req1, res, jest.fn());
+    await middleware(req2, res, jest.fn());
+
+    const key1 = (mockRedis.get as jest.Mock).mock.calls[0][0];
+    const key2 = (mockRedis.get as jest.Mock).mock.calls[1][0];
+    expect(key1).toBe(key2);
+  });
+
+  it('includes varyBy header in cache key when present via req.get', async () => {
+    const middleware = cacheMiddleware({ varyBy: ['accept-language'] });
+    const req = makeReq();
+    (req.get as jest.Mock).mockImplementation((h: string) =>
+      h === 'accept-language' ? 'fr-FR' : undefined
+    );
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    const cacheKeyCall = (mockRedis.get as jest.Mock).mock.calls[0][0];
+    expect(cacheKeyCall).toContain('fr-FR');
+  });
+
+  it('uses req.body value for varyBy when req.get returns nothing', async () => {
+    const middleware = cacheMiddleware({ varyBy: ['x-tenant'] });
+    const req = makeReq({ body: { 'x-tenant': 'acme' } });
+    (req.get as jest.Mock).mockReturnValue(undefined);
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    const cacheKeyCall = (mockRedis.get as jest.Mock).mock.calls[0][0];
+    expect(cacheKeyCall).toContain('acme');
+  });
+
+  it('omits varyBy entry from cache key when neither req.get nor req.body has a value', async () => {
+    const middleware = cacheMiddleware({ varyBy: ['x-tenant'] });
+    const req = makeReq({ body: {} });
+    (req.get as jest.Mock).mockReturnValue(undefined);
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    const cacheKeyCall = (mockRedis.get as jest.Mock).mock.calls[0][0];
+    expect(cacheKeyCall).not.toContain('x-tenant:');
+  });
+
+  it('omits varyBy entry when req.body is undefined (optional chaining null branch)', async () => {
+    const middleware = cacheMiddleware({ varyBy: ['x-tenant'] });
+    const req = makeReq({ body: undefined });
+    (req.get as jest.Mock).mockReturnValue(undefined);
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    const cacheKeyCall = (mockRedis.get as jest.Mock).mock.calls[0][0];
+    expect(cacheKeyCall).not.toContain('x-tenant:');
+  });
+
+  it('hashes cache key when it exceeds 100 chars', async () => {
+    const middleware = cacheMiddleware({
+      keyPrefix: 'a'.repeat(50),
+    });
+    const req = makeReq({
+      path: '/very/long/path/that/makes/the/key/exceed/100/characters/easily',
+    });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    const cacheKeyCall = (mockRedis.get as jest.Mock).mock.calls[0][0];
+    // Hashed key contains only the prefix + md5 hash (32 hex chars)
+    expect(cacheKeyCall).toMatch(/^cache:.+:[a-f0-9]{32}$/);
+  });
+});
+
+// ─── CacheInvalidator ─────────────────────────────────────────────────────────
+
+describe('CacheInvalidator', () => {
+  beforeEach(() => {
+    (mockRedis.getClient as jest.Mock).mockReturnValue(mockRaw);
+    (mockRaw.keys as jest.Mock).mockResolvedValue([]);
+    (mockRaw.del as jest.Mock).mockResolvedValue(1);
+  });
+
+  it('invalidateByPattern returns 0 when no client', async () => {
+    (mockRedis.getClient as jest.Mock).mockReturnValue(null);
+    const result = await CacheInvalidator.invalidateByPattern('test');
+    expect(result).toBe(0);
+  });
+
+  it('invalidateByPattern returns 0 when no matching keys', async () => {
+    (mockRaw.keys as jest.Mock).mockResolvedValue([]);
+    const result = await CacheInvalidator.invalidateByPattern('test');
+    expect(result).toBe(0);
+  });
+
+  it('invalidateByPattern deletes matching keys and returns count', async () => {
+    (mockRaw.keys as jest.Mock).mockResolvedValue(['cache:key1', 'cache:key2']);
+    const result = await CacheInvalidator.invalidateByPattern('test');
+    expect(mockRaw.del).toHaveBeenCalledWith(['cache:key1', 'cache:key2']);
+    expect(result).toBe(2);
+  });
+
+  it('invalidatePath delegates to invalidateByPattern', async () => {
+    (mockRaw.keys as jest.Mock).mockResolvedValue(['cache:GET:/api/users']);
+    const result = await CacheInvalidator.invalidatePath('/api/users');
+    expect(result).toBe(1);
+  });
+
+  it('invalidateAll calls invalidateByPattern with empty string', async () => {
+    (mockRaw.keys as jest.Mock).mockResolvedValue(['cache:x', 'cache:y', 'cache:z']);
+    const result = await CacheInvalidator.invalidateAll();
+    expect(result).toBe(3);
+  });
+
+  it('invalidateByPrefix delegates to invalidateByPattern', async () => {
+    (mockRaw.keys as jest.Mock).mockResolvedValue(['cache:user:1']);
+    const result = await CacheInvalidator.invalidateByPrefix('user:');
+    expect(result).toBe(1);
+  });
+
+  it('invalidateByPattern returns 0 on error', async () => {
+    (mockRaw.keys as jest.Mock).mockRejectedValue(new Error('Redis error'));
+    const result = await CacheInvalidator.invalidateByPattern('test');
+    expect(result).toBe(0);
+  });
+});
+
+// ─── pre-configured cache exports ─────────────────────────────────────────────
+
+describe('cache pre-configured instances', () => {
+  it('cache.short, medium, long, veryLong are functions (middleware)', () => {
+    expect(typeof cache.short).toBe('function');
+    expect(typeof cache.medium).toBe('function');
+    expect(typeof cache.long).toBe('function');
+    expect(typeof cache.veryLong).toBe('function');
+  });
+
+  it('cache.custom returns a middleware function', () => {
+    const mw = cache.custom({ ttl: 45 });
+    expect(typeof mw).toBe('function');
+  });
+});

--- a/tests/DR-538-US-TEST-002/unit/errorHandler.test.ts
+++ b/tests/DR-538-US-TEST-002/unit/errorHandler.test.ts
@@ -1,0 +1,112 @@
+import { Request, Response, NextFunction } from 'express';
+import { errorHandler, notFoundHandler, ApiError } from '../../../../dreamscape-services/auth/src/middleware/errorHandler';
+
+function makeRes() {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+function makeReq(overrides: Partial<Request> = {}): Request {
+  return {
+    url: '/test',
+    method: 'GET',
+    originalUrl: '/test',
+    ...overrides,
+  } as Request;
+}
+
+// ─── errorHandler ─────────────────────────────────────────────────────────────
+
+describe('errorHandler', () => {
+  it('uses err.statusCode and err.message when provided', () => {
+    const err: ApiError = Object.assign(new Error('Not allowed'), { statusCode: 403 });
+    const req = makeReq({ url: '/secure' });
+    const res = makeRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      error: expect.objectContaining({
+        message: 'Not allowed',
+        status: 403,
+        path: '/secure',
+      }),
+    }));
+  });
+
+  it('defaults to 500 and "Internal Server Error" when statusCode/message missing', () => {
+    const err: ApiError = new Error('');
+    err.message = '';
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      error: expect.objectContaining({
+        status: 500,
+        message: 'Internal Server Error',
+      }),
+    }));
+  });
+
+  it('includes timestamp in the response body', () => {
+    const err: ApiError = new Error('oops');
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    errorHandler(err, req, res, next);
+
+    const body = (res.json as jest.Mock).mock.calls[0][0];
+    expect(body.error.timestamp).toBeDefined();
+    expect(() => new Date(body.error.timestamp)).not.toThrow();
+  });
+
+  it('uses err.statusCode 400 correctly', () => {
+    const err: ApiError = Object.assign(new Error('Bad input'), { statusCode: 400 });
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});
+
+// ─── notFoundHandler ──────────────────────────────────────────────────────────
+
+describe('notFoundHandler', () => {
+  it('returns 404 with the original URL in the message', () => {
+    const req = makeReq({ originalUrl: '/api/v1/missing' });
+    const res = makeRes();
+
+    notFoundHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      error: expect.objectContaining({
+        status: 404,
+        message: expect.stringContaining('/api/v1/missing'),
+        path: '/api/v1/missing',
+      }),
+    }));
+  });
+
+  it('includes a timestamp in the 404 response', () => {
+    const req = makeReq({ originalUrl: '/nope' });
+    const res = makeRes();
+
+    notFoundHandler(req, res);
+
+    const body = (res.json as jest.Mock).mock.calls[0][0];
+    expect(body.error.timestamp).toBeDefined();
+  });
+});

--- a/tests/DR-538-US-TEST-002/unit/rateLimiter.test.ts
+++ b/tests/DR-538-US-TEST-002/unit/rateLimiter.test.ts
@@ -1,0 +1,170 @@
+/**
+ * rateLimiter.test.ts - DR-538-US-TEST-002
+ *
+ * rateLimiter.ts calls createRedisStore() at module-load time.
+ * We use jest.isolateModules() to re-execute the module with different
+ * Redis mock states so both branches are exercised.
+ */
+
+// The @config/redis mock is resolved via moduleNameMapper
+import mockRedisClient, { mockRawClient } from '../../../../dreamscape-tests/__mocks__/redis';
+
+function makeReq(overrides: any = {}): any {
+  return {
+    ip: '127.0.0.1',
+    body: {},
+    ...overrides,
+  };
+}
+
+// ─── Redis available (default mock state: isReady=true, getClient returns mock) ──
+
+describe('rateLimiter — Redis available', () => {
+  let loginLimiter: any;
+  let registerLimiter: any;
+  let authLimiter: any;
+  let refreshLimiter: any;
+  let capturedSendCommand: ((...args: string[]) => any) | undefined;
+
+  beforeAll(() => {
+    jest.isolateModules(() => {
+      (mockRedisClient.isReady as jest.Mock).mockReturnValue(true);
+      (mockRedisClient.getClient as jest.Mock).mockReturnValue(mockRawClient);
+
+      // Re-mock express-rate-limit to capture config
+      jest.mock('express-rate-limit', () => jest.fn((config: any) => config));
+      jest.mock('rate-limit-redis', () => ({
+        RedisStore: jest.fn().mockImplementation((opts: any) => {
+          capturedSendCommand = opts.sendCommand;
+          return { type: 'redis-store' };
+        }),
+      }));
+
+      const mod = require('../../../../dreamscape-services/auth/src/middleware/rateLimiter');
+      loginLimiter = mod.loginLimiter;
+      registerLimiter = mod.registerLimiter;
+      authLimiter = mod.authLimiter;
+      refreshLimiter = mod.refreshLimiter;
+    });
+  });
+
+  it('loginLimiter has correct windowMs and max', () => {
+    expect(loginLimiter.windowMs).toBe(15 * 60 * 1000);
+    expect(loginLimiter.max).toBe(5);
+  });
+
+  it('loginLimiter skipSuccessfulRequests is true', () => {
+    expect(loginLimiter.skipSuccessfulRequests).toBe(true);
+  });
+
+  it('loginLimiter keyGenerator includes email and ip', () => {
+    const req = makeReq({ ip: '1.2.3.4', body: { email: 'user@test.com' } });
+    const key = loginLimiter.keyGenerator(req);
+    expect(key).toBe('login:1.2.3.4-user@test.com');
+  });
+
+  it('loginLimiter keyGenerator falls back to "unknown" when no email', () => {
+    const req = makeReq({ ip: '1.2.3.4', body: {} });
+    const key = loginLimiter.keyGenerator(req);
+    expect(key).toBe('login:1.2.3.4-unknown');
+  });
+
+  it('registerLimiter has correct windowMs and max', () => {
+    expect(registerLimiter.windowMs).toBe(60 * 60 * 1000);
+    expect(registerLimiter.max).toBe(3);
+  });
+
+  it('registerLimiter keyGenerator uses ip only', () => {
+    const req = makeReq({ ip: '5.5.5.5' });
+    const key = registerLimiter.keyGenerator(req);
+    expect(key).toBe('register:5.5.5.5');
+  });
+
+  it('authLimiter has correct windowMs and max', () => {
+    expect(authLimiter.windowMs).toBe(15 * 60 * 1000);
+    expect(authLimiter.max).toBe(100);
+  });
+
+  it('authLimiter keyGenerator prefixes with auth:', () => {
+    const req = makeReq({ ip: '10.0.0.1' });
+    const key = authLimiter.keyGenerator(req);
+    expect(key).toBe('auth:10.0.0.1');
+  });
+
+  it('refreshLimiter has correct windowMs and max', () => {
+    expect(refreshLimiter.windowMs).toBe(15 * 60 * 1000);
+    expect(refreshLimiter.max).toBe(20);
+  });
+
+  it('refreshLimiter keyGenerator prefixes with refresh:', () => {
+    const req = makeReq({ ip: '10.0.0.2' });
+    const key = refreshLimiter.keyGenerator(req);
+    expect(key).toBe('refresh:10.0.0.2');
+  });
+
+  it('all limiters use a Redis store when Redis is ready', () => {
+    expect(loginLimiter.store).toBeDefined();
+    expect(loginLimiter.store.type).toBe('redis-store');
+    expect(registerLimiter.store.type).toBe('redis-store');
+    expect(authLimiter.store.type).toBe('redis-store');
+    expect(refreshLimiter.store.type).toBe('redis-store');
+  });
+
+  it('all limiters have legacyHeaders=false and standardHeaders=true', () => {
+    for (const limiter of [loginLimiter, registerLimiter, authLimiter, refreshLimiter]) {
+      expect(limiter.legacyHeaders).toBe(false);
+      expect(limiter.standardHeaders).toBe(true);
+    }
+  });
+
+  it('all limiters have RATE_LIMIT_EXCEEDED code in message', () => {
+    for (const limiter of [loginLimiter, registerLimiter, authLimiter, refreshLimiter]) {
+      expect(limiter.message.code).toBe('RATE_LIMIT_EXCEEDED');
+      expect(limiter.message.success).toBe(false);
+    }
+  });
+
+  it('RedisStore sendCommand wraps variadic args into an array and calls client.sendCommand', () => {
+    expect(typeof capturedSendCommand).toBe('function');
+    // capturedSendCommand is (...args) => client.sendCommand(args)
+    // client here is the isolated registry's mockRawClient — a distinct jest.fn() instance.
+    // Calling it exercises the arrow function body at rateLimiter.ts:15.
+    expect(() => capturedSendCommand!('PING')).not.toThrow();
+  });
+
+  it('loginLimiter keyGenerator handles undefined req.body (optional chaining null branch)', () => {
+    const req = makeReq({ ip: '1.2.3.4', body: undefined });
+    const key = loginLimiter.keyGenerator(req);
+    expect(key).toBe('login:1.2.3.4-unknown');
+  });
+});
+
+// ─── Redis NOT available ──────────────────────────────────────────────────────
+
+describe('rateLimiter — Redis NOT available (fallback to memory store)', () => {
+  it('logs a warning and uses memory store when Redis not available', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    jest.isolateModules(() => {
+      // Override @config/redis with a factory so the isolated registry gets
+      // an instance where isReady() returns false (the outer mock is in a
+      // different registry and its state doesn't bleed in)
+      jest.mock('@config/redis', () => ({
+        __esModule: true,
+        default: {
+          isReady: jest.fn().mockReturnValue(false),
+          getClient: jest.fn().mockReturnValue(null),
+        },
+      }));
+      jest.mock('express-rate-limit', () => jest.fn((config: any) => config));
+      jest.mock('rate-limit-redis', () => ({ RedisStore: jest.fn() }));
+
+      require('../../../../dreamscape-services/auth/src/middleware/rateLimiter');
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Redis not available, falling back to memory store for rate limiting'
+    );
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/DR-538-US-TEST-002/unit/sessionManager.test.ts
+++ b/tests/DR-538-US-TEST-002/unit/sessionManager.test.ts
@@ -1,0 +1,373 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import mockRedisClient, { mockRawClient } from '../../../../dreamscape-tests/__mocks__/redis';
+import {
+  SessionManager,
+  validateSession,
+} from '../../../../dreamscape-services/auth/src/middleware/sessionManager';
+
+const mockRedis = mockRedisClient as jest.Mocked<typeof mockRedisClient>;
+const mockRaw = mockRawClient as jest.Mocked<typeof mockRawClient>;
+
+const SESSION_DATA = {
+  userId: 'u1',
+  email: 'test@test.com',
+  createdAt: Date.now(),
+  lastActivity: Date.now(),
+  ipAddress: '127.0.0.1',
+  userAgent: 'jest',
+};
+
+function makeReq(overrides: any = {}): Request {
+  return {
+    ip: '127.0.0.1',
+    get: jest.fn().mockReturnValue('jest-agent'),
+    headers: {},
+    ...overrides,
+  } as unknown as Request;
+}
+
+function makeRes() {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  (mockRedis.get as jest.Mock).mockResolvedValue(null);
+  (mockRedis.set as jest.Mock).mockResolvedValue(true);
+  (mockRedis.del as jest.Mock).mockResolvedValue(1);
+  (mockRedis.exists as jest.Mock).mockResolvedValue(false);
+  (mockRedis.expire as jest.Mock).mockResolvedValue(true);
+  (mockRedis.getClient as jest.Mock).mockReturnValue(mockRaw);
+  (mockRaw.sAdd as jest.Mock).mockResolvedValue(1);
+  (mockRaw.sRem as jest.Mock).mockResolvedValue(1);
+  (mockRaw.sMembers as jest.Mock).mockResolvedValue([]);
+});
+
+// ─── createSession ────────────────────────────────────────────────────────────
+
+describe('SessionManager.createSession', () => {
+  it('returns true on successful session creation', async () => {
+    (mockRedis.set as jest.Mock).mockResolvedValue(true);
+    const req = makeReq();
+    const result = await SessionManager.createSession('u1', 'test@test.com', 'tok1', req);
+    expect(result).toBe(true);
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      'session:tok1',
+      expect.stringContaining('"userId":"u1"'),
+      86400
+    );
+  });
+
+  it('adds token to user sessions set via sAdd', async () => {
+    const req = makeReq();
+    await SessionManager.createSession('u1', 'test@test.com', 'tok1', req);
+    expect(mockRaw.sAdd).toHaveBeenCalledWith('user_sessions:u1', 'tok1');
+  });
+
+  it('returns false when Redis.set fails', async () => {
+    (mockRedis.set as jest.Mock).mockResolvedValue(false);
+    const req = makeReq();
+    const result = await SessionManager.createSession('u1', 'test@test.com', 'tok1', req);
+    expect(result).toBe(false);
+  });
+
+  it('skips sAdd when getClient returns null', async () => {
+    (mockRedis.getClient as jest.Mock).mockReturnValue(null);
+    const req = makeReq();
+    await SessionManager.createSession('u1', 'test@test.com', 'tok1', req);
+    expect(mockRaw.sAdd).not.toHaveBeenCalled();
+  });
+
+  it('returns false on Redis error', async () => {
+    (mockRedis.set as jest.Mock).mockRejectedValue(new Error('Redis down'));
+    const req = makeReq();
+    const result = await SessionManager.createSession('u1', 'test@test.com', 'tok1', req);
+    expect(result).toBe(false);
+  });
+});
+
+// ─── getSession ───────────────────────────────────────────────────────────────
+
+describe('SessionManager.getSession', () => {
+  it('returns parsed session data when found', async () => {
+    (mockRedis.get as jest.Mock).mockResolvedValue(JSON.stringify(SESSION_DATA));
+    const result = await SessionManager.getSession('tok1');
+    expect(result).toMatchObject({ userId: 'u1', email: 'test@test.com' });
+  });
+
+  it('returns null when session not found', async () => {
+    const result = await SessionManager.getSession('tok1');
+    expect(result).toBeNull();
+  });
+
+  it('returns null on Redis error', async () => {
+    (mockRedis.get as jest.Mock).mockRejectedValue(new Error('fail'));
+    const result = await SessionManager.getSession('tok1');
+    expect(result).toBeNull();
+  });
+});
+
+// ─── updateSessionActivity ────────────────────────────────────────────────────
+
+describe('SessionManager.updateSessionActivity', () => {
+  it('returns false when session not found', async () => {
+    const result = await SessionManager.updateSessionActivity('tok1');
+    expect(result).toBe(false);
+  });
+
+  it('updates lastActivity and returns true', async () => {
+    (mockRedis.get as jest.Mock).mockResolvedValue(JSON.stringify(SESSION_DATA));
+    (mockRedis.set as jest.Mock).mockResolvedValue(true);
+    const before = SESSION_DATA.lastActivity;
+    const result = await SessionManager.updateSessionActivity('tok1');
+    expect(result).toBe(true);
+    const savedArg = JSON.parse((mockRedis.set as jest.Mock).mock.calls[0][1]);
+    expect(savedArg.lastActivity).toBeGreaterThanOrEqual(before);
+  });
+
+  it('returns false when Redis.set throws after session found', async () => {
+    (mockRedis.get as jest.Mock).mockResolvedValue(JSON.stringify(SESSION_DATA));
+    (mockRedis.set as jest.Mock).mockRejectedValue(new Error('set fail'));
+    const result = await SessionManager.updateSessionActivity('tok1');
+    expect(result).toBe(false);
+  });
+
+  it('returns false on Redis.get error', async () => {
+    (mockRedis.get as jest.Mock).mockRejectedValue(new Error('fail'));
+    const result = await SessionManager.updateSessionActivity('tok1');
+    expect(result).toBe(false);
+  });
+});
+
+// ─── deleteSession ────────────────────────────────────────────────────────────
+
+describe('SessionManager.deleteSession', () => {
+  it('deletes the session key', async () => {
+    await SessionManager.deleteSession('tok1', 'u1');
+    expect(mockRedis.del).toHaveBeenCalledWith('session:tok1');
+  });
+
+  it('calls sRem to remove token from user session set', async () => {
+    await SessionManager.deleteSession('tok1', 'u1');
+    expect(mockRaw.sRem).toHaveBeenCalledWith('user_sessions:u1', 'tok1');
+  });
+
+  it('looks up userId from session when not provided', async () => {
+    (mockRedis.get as jest.Mock).mockResolvedValue(JSON.stringify(SESSION_DATA));
+    await SessionManager.deleteSession('tok1');
+    expect(mockRaw.sRem).toHaveBeenCalledWith('user_sessions:u1', 'tok1');
+  });
+
+  it('skips sRem when getClient returns null', async () => {
+    (mockRedis.getClient as jest.Mock).mockReturnValue(null);
+    await SessionManager.deleteSession('tok1', 'u1');
+    expect(mockRaw.sRem).not.toHaveBeenCalled();
+  });
+
+  it('returns true on success', async () => {
+    const result = await SessionManager.deleteSession('tok1', 'u1');
+    expect(result).toBe(true);
+  });
+
+  it('returns false on Redis error', async () => {
+    (mockRedis.del as jest.Mock).mockRejectedValue(new Error('fail'));
+    const result = await SessionManager.deleteSession('tok1', 'u1');
+    expect(result).toBe(false);
+  });
+});
+
+// ─── deleteAllUserSessions ────────────────────────────────────────────────────
+
+describe('SessionManager.deleteAllUserSessions', () => {
+  it('returns false when getClient returns null', async () => {
+    (mockRedis.getClient as jest.Mock).mockReturnValue(null);
+    const result = await SessionManager.deleteAllUserSessions('u1');
+    expect(result).toBe(false);
+  });
+
+  it('deletes each session and the user sessions set', async () => {
+    (mockRaw.sMembers as jest.Mock).mockResolvedValue(['tok1', 'tok2']);
+    const result = await SessionManager.deleteAllUserSessions('u1');
+    expect(mockRedis.del).toHaveBeenCalledWith('session:tok1');
+    expect(mockRedis.del).toHaveBeenCalledWith('session:tok2');
+    expect(mockRedis.del).toHaveBeenCalledWith('user_sessions:u1');
+    expect(result).toBe(true);
+  });
+
+  it('returns true when no sessions exist for user', async () => {
+    (mockRaw.sMembers as jest.Mock).mockResolvedValue([]);
+    const result = await SessionManager.deleteAllUserSessions('u1');
+    expect(result).toBe(true);
+  });
+
+  it('returns false on error', async () => {
+    (mockRaw.sMembers as jest.Mock).mockRejectedValue(new Error('fail'));
+    const result = await SessionManager.deleteAllUserSessions('u1');
+    expect(result).toBe(false);
+  });
+});
+
+// ─── getUserSessions ──────────────────────────────────────────────────────────
+
+describe('SessionManager.getUserSessions', () => {
+  it('returns empty array when getClient returns null', async () => {
+    (mockRedis.getClient as jest.Mock).mockReturnValue(null);
+    const result = await SessionManager.getUserSessions('u1');
+    expect(result).toEqual([]);
+  });
+
+  it('returns active sessions data', async () => {
+    (mockRaw.sMembers as jest.Mock).mockResolvedValue(['tok1', 'tok2']);
+    (mockRedis.get as jest.Mock)
+      .mockResolvedValueOnce(JSON.stringify(SESSION_DATA))
+      .mockResolvedValueOnce(JSON.stringify({ ...SESSION_DATA, userId: 'u1', email: 'other@b.com' }));
+    const result = await SessionManager.getUserSessions('u1');
+    expect(result).toHaveLength(2);
+  });
+
+  it('skips tokens with no session data', async () => {
+    (mockRaw.sMembers as jest.Mock).mockResolvedValue(['tok1', 'tok2']);
+    (mockRedis.get as jest.Mock)
+      .mockResolvedValueOnce(JSON.stringify(SESSION_DATA))
+      .mockResolvedValueOnce(null);
+    const result = await SessionManager.getUserSessions('u1');
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns empty array on error', async () => {
+    (mockRaw.sMembers as jest.Mock).mockRejectedValue(new Error('fail'));
+    const result = await SessionManager.getUserSessions('u1');
+    expect(result).toEqual([]);
+  });
+});
+
+// ─── isTokenBlacklisted ───────────────────────────────────────────────────────
+
+describe('SessionManager.isTokenBlacklisted', () => {
+  it('returns false when token not in blacklist', async () => {
+    (mockRedis.exists as jest.Mock).mockResolvedValue(false);
+    const result = await SessionManager.isTokenBlacklisted('tok1');
+    expect(result).toBe(false);
+  });
+
+  it('returns true when token is blacklisted', async () => {
+    (mockRedis.exists as jest.Mock).mockResolvedValue(true);
+    const result = await SessionManager.isTokenBlacklisted('tok1');
+    expect(result).toBe(true);
+  });
+
+  it('checks blacklist: prefixed key', async () => {
+    await SessionManager.isTokenBlacklisted('tok1');
+    expect(mockRedis.exists).toHaveBeenCalledWith('blacklist:tok1');
+  });
+
+  it('returns false on Redis error', async () => {
+    (mockRedis.exists as jest.Mock).mockRejectedValue(new Error('fail'));
+    const result = await SessionManager.isTokenBlacklisted('tok1');
+    expect(result).toBe(false);
+  });
+});
+
+// ─── blacklistToken ───────────────────────────────────────────────────────────
+
+describe('SessionManager.blacklistToken', () => {
+  it('uses provided TTL directly', async () => {
+    await SessionManager.blacklistToken('tok1', 300);
+    expect(mockRedis.set).toHaveBeenCalledWith('blacklist:tok1', '1', 300);
+  });
+
+  it('extracts TTL from JWT exp when no TTL provided', async () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 600;
+    const token = jwt.sign({ exp: futureExp }, 'secret');
+    await SessionManager.blacklistToken(token);
+    const call = (mockRedis.set as jest.Mock).mock.calls[0];
+    expect(call[0]).toBe(`blacklist:${token}`);
+    expect(call[2]).toBeGreaterThan(0);
+    expect(call[2]).toBeLessThanOrEqual(600);
+  });
+
+  it('falls back to SESSION_TTL when token has no exp', async () => {
+    await SessionManager.blacklistToken('not-a-jwt');
+    const call = (mockRedis.set as jest.Mock).mock.calls[0];
+    expect(call[2]).toBe(86400);
+  });
+
+  it('falls back to SESSION_TTL when jwt.decode throws', async () => {
+    const jwtModule = require('jsonwebtoken');
+    jest.spyOn(jwtModule, 'decode').mockImplementationOnce(() => { throw new Error('decode error'); });
+    await SessionManager.blacklistToken('any-token');
+    const call = (mockRedis.set as jest.Mock).mock.calls[0];
+    expect(call[2]).toBe(86400);
+  });
+
+  it('returns false on Redis error', async () => {
+    (mockRedis.set as jest.Mock).mockRejectedValue(new Error('fail'));
+    const result = await SessionManager.blacklistToken('tok1', 60);
+    expect(result).toBe(false);
+  });
+});
+
+// ─── validateSession middleware ───────────────────────────────────────────────
+
+describe('validateSession middleware', () => {
+  it('returns 401 when no token in Authorization header', async () => {
+    const req = makeReq({ headers: {} });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await validateSession(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'No token provided' });
+  });
+
+  it('returns 401 when token is blacklisted', async () => {
+    const req = makeReq({ headers: { authorization: 'Bearer tok-blacklisted' } });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockRedis.exists as jest.Mock).mockResolvedValue(true);
+    await validateSession(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Token has been revoked' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when session not found in Redis', async () => {
+    const req = makeReq({ headers: { authorization: 'Bearer tok-no-session' } });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockRedis.exists as jest.Mock).mockResolvedValue(false);
+    (mockRedis.get as jest.Mock).mockResolvedValue(null);
+    await validateSession(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid or expired session' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls next and attaches session data when valid', async () => {
+    const req = makeReq({ headers: { authorization: 'Bearer tok-valid' } });
+    const res = makeRes();
+    const next = jest.fn();
+    (mockRedis.exists as jest.Mock).mockResolvedValue(false);
+    (mockRedis.get as jest.Mock).mockResolvedValue(JSON.stringify(SESSION_DATA));
+    (mockRedis.set as jest.Mock).mockResolvedValue(true);
+    await validateSession(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect((req as any).session).toMatchObject({ userId: 'u1', email: 'test@test.com' });
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    const req = makeReq({ headers: { authorization: 'Bearer tok-error' } });
+    const res = makeRes();
+    const next = jest.fn();
+    // SessionManager methods catch their own errors internally, so we spy directly
+    // on the static method to simulate an unhandled exception reaching validateSession
+    jest.spyOn(SessionManager, 'isTokenBlacklisted').mockRejectedValueOnce(new Error('unexpected'));
+    await validateSession(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' });
+  });
+});


### PR DESCRIPTION
…-002

- Introduced jest.config.test002.js for unit testing specific to DR-538-US-TEST-002.
- Added unit tests for authentication, caching, error handling, rate limiting, and session management.
- Created mock implementations for Redis and other dependencies to facilitate testing.
- Updated package.json with new test scripts for the added configuration.

This commit enhances test coverage and ensures robust functionality for the authentication middleware and related services.