### PR TITLE
feat(tests): add Jest configuration and unit tests for DR-538-US-TEST…

### DIFF
--- a/jest.config.test024.js
+++ b/jest.config.test024.js
@@ -1,0 +1,44 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  testEnvironment: 'node',
+  rootDir: '../',
+
+  roots: [
+    '<rootDir>/dreamscape-tests/tests/DR-538-US-TEST-024',
+    '<rootDir>/dreamscape-services/payment/src/services',
+  ],
+  testMatch: ['**/DR-538-US-TEST-024/**/*.test.ts'],
+
+  moduleNameMapper: {
+    '^@dreamscape/kafka$': '<rootDir>/dreamscape-services/shared/kafka/dist/index.js',
+    '^@dreamscape/db$': '<rootDir>/dreamscape-tests/__mocks__/db.ts',
+  },
+
+  setupFilesAfterEnv: ['<rootDir>/dreamscape-tests/jest.setup.js'],
+
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  transform: {
+    '^.+\\.ts$': ['<rootDir>/dreamscape-tests/node_modules/ts-jest', {
+      diagnostics: false,
+      tsconfig: {
+        module: 'commonjs',
+        esModuleInterop: true,
+        allowSyntheticDefaultImports: true,
+        strict: false,
+      },
+    }],
+  },
+
+  collectCoverageFrom: [
+    '<rootDir>/dreamscape-services/payment/src/services/KafkaService.ts',
+    '<rootDir>/dreamscape-services/payment/src/services/DatabaseService.ts',
+  ],
+  coverageDirectory: '<rootDir>/dreamscape-tests/coverage/test024',
+  coverageThreshold: {
+    global: { branches: 80, functions: 80, lines: 80, statements: 80 },
+  },
+
+  clearMocks: true,
+  testTimeout: 10000,
+  verbose: true,
+};

--- a/package.json
+++ b/package.json
@@ -36,11 +36,10 @@
     "test:test004:coverage": "jest --config=jest.config.test004.js --coverage",
     "test:test022": "jest --config=jest.config.test022.js --verbose",
     "test:test022:coverage": "jest --config=jest.config.test022.js --coverage",
-<<<<<<< HEAD
-=======
     "test:test023": "jest --config=jest.config.test023.js --verbose",
     "test:test023:coverage": "jest --config=jest.config.test023.js --coverage",
->>>>>>> main
+    "test:test024": "jest --config=jest.config.test024.js --verbose",
+    "test:test024:coverage": "jest --config=jest.config.test024.js --coverage",
     "test:performance": "npm run test:performance:api && npm run test:performance:frontend",
     "test:performance:api": "echo 'API performance tests - to be implemented'",
     "test:performance:frontend": "echo 'Frontend performance tests - to be implemented'",

--- a/tests/DR-538-US-TEST-024/unit/databaseService.test.ts
+++ b/tests/DR-538-US-TEST-024/unit/databaseService.test.ts
@@ -1,0 +1,361 @@
+/**
+ * databaseService.test.ts — DR-538-US-TEST-024
+ *
+ * Unit tests for DatabaseService.
+ * PrismaClient is mocked via __mocks__/db.ts.
+ * databaseService is a singleton; isInitialized is reset in beforeEach.
+ */
+
+// ─── Imports ──────────────────────────────────────────────────────────────────
+
+import databaseService from '../../../../dreamscape-services/payment/src/services/DatabaseService';
+import { PaymentTransactionStatus } from '@dreamscape/db';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Access the mock PrismaClient instance held by the singleton. */
+function getPrisma() {
+  return (databaseService as any).prisma;
+}
+
+function resetService() {
+  (databaseService as any).isInitialized = false;
+}
+
+// ─── Setup / teardown ─────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  resetService();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ─── initialize() ─────────────────────────────────────────────────────────────
+
+describe('initialize()', () => {
+  it('calls $connect and sets isInitialized on first call', async () => {
+    getPrisma().$connect.mockResolvedValueOnce(undefined);
+
+    await databaseService.initialize();
+
+    expect(getPrisma().$connect).toHaveBeenCalledTimes(1);
+    expect((databaseService as any).isInitialized).toBe(true);
+  });
+
+  it('skips $connect and logs when already initialized', async () => {
+    (databaseService as any).isInitialized = true;
+
+    await databaseService.initialize();
+
+    expect(getPrisma().$connect).not.toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith('[DatabaseService] Already initialized');
+  });
+
+  it('rethrows and stays uninitialized when $connect throws', async () => {
+    getPrisma().$connect.mockRejectedValueOnce(new Error('DB unreachable'));
+
+    await expect(databaseService.initialize()).rejects.toThrow('DB unreachable');
+    expect(console.error).toHaveBeenCalled();
+    expect((databaseService as any).isInitialized).toBe(false);
+  });
+});
+
+// ─── shutdown() ───────────────────────────────────────────────────────────────
+
+describe('shutdown()', () => {
+  it('calls $disconnect and clears isInitialized', async () => {
+    (databaseService as any).isInitialized = true;
+    getPrisma().$disconnect.mockResolvedValueOnce(undefined);
+
+    await databaseService.shutdown();
+
+    expect(getPrisma().$disconnect).toHaveBeenCalledTimes(1);
+    expect((databaseService as any).isInitialized).toBe(false);
+  });
+});
+
+// ─── isEventProcessed() ───────────────────────────────────────────────────────
+
+describe('isEventProcessed()', () => {
+  it('returns true when event record exists', async () => {
+    getPrisma().processedWebhookEvent.findUnique.mockResolvedValueOnce({ eventId: 'evt_123' });
+
+    const result = await databaseService.isEventProcessed('evt_123');
+
+    expect(result).toBe(true);
+    expect(getPrisma().processedWebhookEvent.findUnique).toHaveBeenCalledWith({
+      where: { eventId: 'evt_123' },
+    });
+  });
+
+  it('returns false when event record does not exist', async () => {
+    getPrisma().processedWebhookEvent.findUnique.mockResolvedValueOnce(null);
+
+    const result = await databaseService.isEventProcessed('evt_new');
+
+    expect(result).toBe(false);
+  });
+});
+
+// ─── markEventAsProcessed() ───────────────────────────────────────────────────
+
+describe('markEventAsProcessed()', () => {
+  it('creates the processed event record on success', async () => {
+    getPrisma().processedWebhookEvent.create.mockResolvedValueOnce(undefined);
+
+    await databaseService.markEventAsProcessed('evt_123', 'payment_intent.succeeded', { foo: 'bar' });
+
+    expect(getPrisma().processedWebhookEvent.create).toHaveBeenCalledWith({
+      data: {
+        eventId: 'evt_123',
+        eventType: 'payment_intent.succeeded',
+        processed: true,
+        payload: { foo: 'bar' },
+      },
+    });
+  });
+
+  it('uses empty object as payload when none is provided', async () => {
+    getPrisma().processedWebhookEvent.create.mockResolvedValueOnce(undefined);
+
+    await databaseService.markEventAsProcessed('evt_456', 'payment_intent.canceled');
+
+    expect(getPrisma().processedWebhookEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ payload: {} }) })
+    );
+  });
+
+  it('silently returns on P2002 (unique constraint / race condition)', async () => {
+    const uniqueError = Object.assign(new Error('Unique constraint failed'), { code: 'P2002' });
+    getPrisma().processedWebhookEvent.create.mockRejectedValueOnce(uniqueError);
+
+    await expect(
+      databaseService.markEventAsProcessed('evt_dup', 'charge.refunded')
+    ).resolves.toBeUndefined();
+
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('already marked as processed')
+    );
+  });
+
+  it('rethrows on non-P2002 errors', async () => {
+    getPrisma().processedWebhookEvent.create.mockRejectedValueOnce(new Error('Network error'));
+
+    await expect(
+      databaseService.markEventAsProcessed('evt_fail', 'payment_intent.succeeded')
+    ).rejects.toThrow('Network error');
+  });
+});
+
+// ─── createTransaction() ──────────────────────────────────────────────────────
+
+describe('createTransaction()', () => {
+  const txData = {
+    paymentIntentId: 'pi_001',
+    bookingId: 'b-001',
+    bookingReference: 'REF-001',
+    userId: 'u-001',
+    amount: 50000,
+    currency: 'EUR',
+  };
+
+  it('calls paymentTransaction.create with PENDING status', async () => {
+    getPrisma().paymentTransaction.create.mockResolvedValueOnce(undefined);
+
+    await databaseService.createTransaction(txData);
+
+    expect(getPrisma().paymentTransaction.create).toHaveBeenCalledWith({
+      data: {
+        ...txData,
+        status: PaymentTransactionStatus.PENDING,
+        metadata: {},
+      },
+    });
+  });
+
+  it('includes metadata when provided', async () => {
+    getPrisma().paymentTransaction.create.mockResolvedValueOnce(undefined);
+    const withMeta = { ...txData, metadata: { source: 'web' } };
+
+    await databaseService.createTransaction(withMeta);
+
+    expect(getPrisma().paymentTransaction.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ metadata: { source: 'web' } }) })
+    );
+  });
+
+  it('rethrows when create fails', async () => {
+    getPrisma().paymentTransaction.create.mockRejectedValueOnce(new Error('DB error'));
+
+    await expect(databaseService.createTransaction(txData)).rejects.toThrow('DB error');
+    expect(console.error).toHaveBeenCalled();
+  });
+});
+
+// ─── updateTransaction() ──────────────────────────────────────────────────────
+
+describe('updateTransaction()', () => {
+  it('calls paymentTransaction.update with correct where clause and data', async () => {
+    getPrisma().paymentTransaction.update.mockResolvedValueOnce(undefined);
+    const updates = { status: PaymentTransactionStatus.SUCCEEDED, confirmedAt: new Date() };
+
+    await databaseService.updateTransaction('pi_001', updates);
+
+    expect(getPrisma().paymentTransaction.update).toHaveBeenCalledWith({
+      where: { paymentIntentId: 'pi_001' },
+      data: updates,
+    });
+  });
+
+  it('rethrows when update fails', async () => {
+    getPrisma().paymentTransaction.update.mockRejectedValueOnce(new Error('Not found'));
+
+    await expect(
+      databaseService.updateTransaction('pi_bad', { status: PaymentTransactionStatus.FAILED })
+    ).rejects.toThrow('Not found');
+    expect(console.error).toHaveBeenCalled();
+  });
+});
+
+// ─── getTransactionByPaymentIntent() ─────────────────────────────────────────
+
+describe('getTransactionByPaymentIntent()', () => {
+  it('returns the transaction record when found', async () => {
+    const record = { paymentIntentId: 'pi_001', amount: 50000 };
+    getPrisma().paymentTransaction.findUnique.mockResolvedValueOnce(record);
+
+    const result = await databaseService.getTransactionByPaymentIntent('pi_001');
+
+    expect(result).toEqual(record);
+    expect(getPrisma().paymentTransaction.findUnique).toHaveBeenCalledWith({
+      where: { paymentIntentId: 'pi_001' },
+    });
+  });
+
+  it('returns null when no record exists', async () => {
+    getPrisma().paymentTransaction.findUnique.mockResolvedValueOnce(null);
+
+    const result = await databaseService.getTransactionByPaymentIntent('pi_missing');
+
+    expect(result).toBeNull();
+  });
+});
+
+// ─── getTransactionsByBooking() ───────────────────────────────────────────────
+
+describe('getTransactionsByBooking()', () => {
+  it('returns all transactions for a booking ordered by createdAt desc', async () => {
+    const records = [{ paymentIntentId: 'pi_001' }, { paymentIntentId: 'pi_002' }];
+    getPrisma().paymentTransaction.findMany.mockResolvedValueOnce(records);
+
+    const result = await databaseService.getTransactionsByBooking('b-001');
+
+    expect(result).toEqual(records);
+    expect(getPrisma().paymentTransaction.findMany).toHaveBeenCalledWith({
+      where: { bookingId: 'b-001' },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+});
+
+// ─── getTransactionsByUser() ──────────────────────────────────────────────────
+
+describe('getTransactionsByUser()', () => {
+  it('returns all transactions for a user ordered by createdAt desc', async () => {
+    const records = [{ paymentIntentId: 'pi_001' }];
+    getPrisma().paymentTransaction.findMany.mockResolvedValueOnce(records);
+
+    const result = await databaseService.getTransactionsByUser('u-001');
+
+    expect(result).toEqual(records);
+    expect(getPrisma().paymentTransaction.findMany).toHaveBeenCalledWith({
+      where: { userId: 'u-001' },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+});
+
+// ─── healthCheck() ────────────────────────────────────────────────────────────
+
+// ─── constructor log config ───────────────────────────────────────────────────
+
+describe('constructor log config', () => {
+  it('passes development log levels when NODE_ENV is development', () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+
+    let capturedLog: any;
+    jest.isolateModules(() => {
+      jest.doMock('@dreamscape/db', () => ({
+        PaymentTransactionStatus: {
+          PENDING: 'PENDING', PROCESSING: 'PROCESSING', SUCCEEDED: 'SUCCEEDED',
+          FAILED: 'FAILED', CANCELED: 'CANCELED', REFUNDED: 'REFUNDED',
+        },
+        PrismaClient: jest.fn().mockImplementation(function (config: any) {
+          capturedLog = config?.log;
+          return {
+            paymentTransaction: { create: jest.fn(), update: jest.fn(), findUnique: jest.fn(), findMany: jest.fn() },
+            processedWebhookEvent: { create: jest.fn(), findUnique: jest.fn() },
+            $connect: jest.fn(),
+            $disconnect: jest.fn(),
+            $queryRaw: jest.fn(),
+          };
+        }),
+      }));
+      require('../../../../dreamscape-services/payment/src/services/DatabaseService');
+    });
+
+    process.env.NODE_ENV = originalEnv;
+    expect(capturedLog).toEqual(['query', 'error', 'warn']);
+  });
+});
+
+// ─── healthCheck() ────────────────────────────────────────────────────────────
+
+describe('healthCheck()', () => {
+  it('returns unhealthy when not initialized', async () => {
+    const result = await databaseService.healthCheck();
+
+    expect(result).toEqual({
+      healthy: false,
+      details: { error: 'Database not initialized' },
+    });
+  });
+
+  it('returns healthy when initialized and $queryRaw resolves', async () => {
+    (databaseService as any).isInitialized = true;
+    getPrisma().$queryRaw.mockResolvedValueOnce([{ '?column?': 1 }]);
+
+    const result = await databaseService.healthCheck();
+
+    expect(result).toEqual({ healthy: true, details: { connected: true } });
+  });
+
+  it('returns unhealthy with error message when $queryRaw throws an Error', async () => {
+    (databaseService as any).isInitialized = true;
+    getPrisma().$queryRaw.mockRejectedValueOnce(new Error('Connection lost'));
+
+    const result = await databaseService.healthCheck();
+
+    expect(result).toEqual({
+      healthy: false,
+      details: { error: 'Connection lost' },
+    });
+  });
+
+  it('returns unhealthy with "Unknown error" when $queryRaw throws a non-Error', async () => {
+    (databaseService as any).isInitialized = true;
+    getPrisma().$queryRaw.mockRejectedValueOnce('plain string error');
+
+    const result = await databaseService.healthCheck();
+
+    expect(result).toEqual({
+      healthy: false,
+      details: { error: 'Unknown error' },
+    });
+  });
+});

--- a/tests/DR-538-US-TEST-024/unit/kafkaService.test.ts
+++ b/tests/DR-538-US-TEST-024/unit/kafkaService.test.ts
@@ -1,0 +1,389 @@
+/**
+ * kafkaService.test.ts — DR-538-US-TEST-024
+ *
+ * Unit tests for PaymentKafkaService.
+ * @dreamscape/kafka is fully mocked (no real broker required).
+ * paymentKafkaService is a singleton; state is reset in beforeEach.
+ */
+
+// ─── Module mocks ─────────────────────────────────────────────────────────────
+
+jest.mock('@dreamscape/kafka', () => ({
+  getKafkaClient: jest.fn(),
+  createEvent: jest.fn(),
+  KAFKA_TOPICS: {
+    PAYMENT_INITIATED: 'dreamscape.payment.initiated',
+    PAYMENT_COMPLETED: 'dreamscape.payment.completed',
+    PAYMENT_FAILED: 'dreamscape.payment.failed',
+    PAYMENT_REFUNDED: 'dreamscape.payment.refunded',
+    VOYAGE_BOOKING_CREATED: 'dreamscape.voyage.booking.created',
+    VOYAGE_BOOKING_CANCELLED: 'dreamscape.voyage.booking.cancelled',
+  },
+  CONSUMER_GROUPS: {
+    PAYMENT_SERVICE: 'dreamscape-payment-service-group',
+  },
+}));
+
+// ─── Imports ──────────────────────────────────────────────────────────────────
+
+import { getKafkaClient, createEvent, KAFKA_TOPICS, CONSUMER_GROUPS } from '@dreamscape/kafka';
+import paymentKafkaService from '../../../../dreamscape-services/payment/src/services/KafkaService';
+
+const mockGetKafkaClient = getKafkaClient as jest.MockedFunction<typeof getKafkaClient>;
+const mockCreateEvent = createEvent as jest.MockedFunction<typeof createEvent>;
+
+// ─── Shared mock objects ───────────────────────────────────────────────────────
+
+const mockClient = {
+  connect: jest.fn().mockResolvedValue(undefined),
+  disconnect: jest.fn().mockResolvedValue(undefined),
+  publish: jest.fn().mockResolvedValue(undefined),
+  subscribe: jest.fn().mockResolvedValue(undefined),
+  healthCheck: jest.fn().mockResolvedValue({ healthy: true, details: { connected: true } }),
+};
+
+const mockEvent = {
+  eventId: 'mock-event-id',
+  eventType: 'mock.event',
+  timestamp: '2024-01-01T00:00:00.000Z',
+  version: '1.0.0',
+  source: 'payment-service',
+  payload: {},
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function resetService() {
+  (paymentKafkaService as any).client = null;
+  (paymentKafkaService as any).isInitialized = false;
+}
+
+function injectClient() {
+  (paymentKafkaService as any).client = mockClient;
+  (paymentKafkaService as any).isInitialized = true;
+}
+
+// ─── Setup / teardown ─────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockGetKafkaClient.mockReturnValue(mockClient as any);
+  mockCreateEvent.mockReturnValue(mockEvent as any);
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  resetService();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ─── initialize() ─────────────────────────────────────────────────────────────
+
+describe('initialize()', () => {
+  it('calls getKafkaClient and connects on first call', async () => {
+    await paymentKafkaService.initialize();
+
+    expect(mockGetKafkaClient).toHaveBeenCalledWith('payment-service');
+    expect(mockClient.connect).toHaveBeenCalledTimes(1);
+    expect((paymentKafkaService as any).isInitialized).toBe(true);
+  });
+
+  it('skips re-initialization when already initialized', async () => {
+    await paymentKafkaService.initialize();
+    await paymentKafkaService.initialize();
+
+    expect(mockClient.connect).toHaveBeenCalledTimes(1);
+    expect(console.log).toHaveBeenCalledWith('[PaymentKafkaService] Already initialized');
+  });
+
+  it('rethrows and stays uninitialized when connect() throws', async () => {
+    mockClient.connect.mockRejectedValueOnce(new Error('Broker unreachable'));
+
+    await expect(paymentKafkaService.initialize()).rejects.toThrow('Broker unreachable');
+    expect(console.error).toHaveBeenCalled();
+    expect((paymentKafkaService as any).isInitialized).toBe(false);
+  });
+});
+
+// ─── shutdown() ───────────────────────────────────────────────────────────────
+
+describe('shutdown()', () => {
+  it('disconnects client and clears isInitialized when client is set', async () => {
+    injectClient();
+
+    await paymentKafkaService.shutdown();
+
+    expect(mockClient.disconnect).toHaveBeenCalledTimes(1);
+    expect((paymentKafkaService as any).isInitialized).toBe(false);
+  });
+
+  it('does nothing when client is null', async () => {
+    await paymentKafkaService.shutdown();
+
+    expect(mockClient.disconnect).not.toHaveBeenCalled();
+  });
+});
+
+// ─── publishPaymentInitiated() ────────────────────────────────────────────────
+
+describe('publishPaymentInitiated()', () => {
+  const payload = {
+    paymentId: 'pay-001',
+    bookingId: 'b-001',
+    userId: 'u-001',
+    amount: 50000,
+    currency: 'EUR',
+    paymentMethod: 'credit_card' as const,
+    initiatedAt: '2024-01-01T00:00:00.000Z',
+  };
+
+  it('warns and skips when client is not initialized', async () => {
+    await paymentKafkaService.publishPaymentInitiated(payload);
+
+    expect(console.warn).toHaveBeenCalledWith(
+      '[PaymentKafkaService] Client not initialized, skipping publish'
+    );
+    expect(mockClient.publish).not.toHaveBeenCalled();
+  });
+
+  it('creates event and publishes to PAYMENT_INITIATED topic', async () => {
+    injectClient();
+
+    await paymentKafkaService.publishPaymentInitiated(payload);
+
+    expect(mockCreateEvent).toHaveBeenCalledWith(
+      'payment.initiated',
+      'payment-service',
+      payload,
+      { correlationId: undefined }
+    );
+    expect(mockClient.publish).toHaveBeenCalledWith(
+      KAFKA_TOPICS.PAYMENT_INITIATED,
+      mockEvent,
+      payload.paymentId
+    );
+  });
+
+  it('forwards correlationId to createEvent when provided', async () => {
+    injectClient();
+
+    await paymentKafkaService.publishPaymentInitiated(payload, 'corr-xyz');
+
+    expect(mockCreateEvent).toHaveBeenCalledWith(
+      'payment.initiated',
+      'payment-service',
+      payload,
+      { correlationId: 'corr-xyz' }
+    );
+  });
+});
+
+// ─── publishPaymentCompleted() ────────────────────────────────────────────────
+
+describe('publishPaymentCompleted()', () => {
+  const payload = {
+    paymentId: 'pay-001',
+    bookingId: 'b-001',
+    userId: 'u-001',
+    amount: 50000,
+    currency: 'EUR',
+    transactionId: 'txn-001',
+    completedAt: '2024-01-01T00:00:00.000Z',
+  };
+
+  it('warns and skips when client is not initialized', async () => {
+    await paymentKafkaService.publishPaymentCompleted(payload);
+
+    expect(console.warn).toHaveBeenCalled();
+    expect(mockClient.publish).not.toHaveBeenCalled();
+  });
+
+  it('creates event and publishes to PAYMENT_COMPLETED topic', async () => {
+    injectClient();
+
+    await paymentKafkaService.publishPaymentCompleted(payload);
+
+    expect(mockCreateEvent).toHaveBeenCalledWith(
+      'payment.completed',
+      'payment-service',
+      payload,
+      { correlationId: undefined }
+    );
+    expect(mockClient.publish).toHaveBeenCalledWith(
+      KAFKA_TOPICS.PAYMENT_COMPLETED,
+      mockEvent,
+      payload.paymentId
+    );
+  });
+});
+
+// ─── publishPaymentFailed() ───────────────────────────────────────────────────
+
+describe('publishPaymentFailed()', () => {
+  const payload = {
+    paymentId: 'pay-001',
+    bookingId: 'b-001',
+    userId: 'u-001',
+    amount: 50000,
+    currency: 'EUR',
+    errorCode: 'card_declined',
+    errorMessage: 'Your card was declined.',
+    failedAt: '2024-01-01T00:00:00.000Z',
+  };
+
+  it('warns and skips when client is not initialized', async () => {
+    await paymentKafkaService.publishPaymentFailed(payload);
+
+    expect(console.warn).toHaveBeenCalled();
+    expect(mockClient.publish).not.toHaveBeenCalled();
+  });
+
+  it('creates event and publishes to PAYMENT_FAILED topic', async () => {
+    injectClient();
+
+    await paymentKafkaService.publishPaymentFailed(payload);
+
+    expect(mockCreateEvent).toHaveBeenCalledWith(
+      'payment.failed',
+      'payment-service',
+      payload,
+      { correlationId: undefined }
+    );
+    expect(mockClient.publish).toHaveBeenCalledWith(
+      KAFKA_TOPICS.PAYMENT_FAILED,
+      mockEvent,
+      payload.paymentId
+    );
+  });
+});
+
+// ─── publishPaymentRefunded() ─────────────────────────────────────────────────
+
+describe('publishPaymentRefunded()', () => {
+  const payload = {
+    paymentId: 'pay-001',
+    bookingId: 'b-001',
+    userId: 'u-001',
+    refundAmount: 50000,
+    currency: 'EUR',
+    refundId: 're_mock',
+    reason: 'requested_by_customer',
+    refundedAt: '2024-01-01T00:00:00.000Z',
+  };
+
+  it('warns and skips when client is not initialized', async () => {
+    await paymentKafkaService.publishPaymentRefunded(payload);
+
+    expect(console.warn).toHaveBeenCalled();
+    expect(mockClient.publish).not.toHaveBeenCalled();
+  });
+
+  it('creates event and publishes to PAYMENT_REFUNDED topic', async () => {
+    injectClient();
+
+    await paymentKafkaService.publishPaymentRefunded(payload);
+
+    expect(mockCreateEvent).toHaveBeenCalledWith(
+      'payment.refunded',
+      'payment-service',
+      payload,
+      { correlationId: undefined }
+    );
+    expect(mockClient.publish).toHaveBeenCalledWith(
+      KAFKA_TOPICS.PAYMENT_REFUNDED,
+      mockEvent,
+      payload.paymentId
+    );
+  });
+});
+
+// ─── subscribeToBookingEvents() ───────────────────────────────────────────────
+
+describe('subscribeToBookingEvents()', () => {
+  it('warns and returns when client is not initialized', async () => {
+    await paymentKafkaService.subscribeToBookingEvents({ onBookingCreated: jest.fn() });
+
+    expect(console.warn).toHaveBeenCalledWith(
+      '[PaymentKafkaService] Client not initialized, cannot subscribe'
+    );
+    expect(mockClient.subscribe).not.toHaveBeenCalled();
+  });
+
+  it('does not call subscribe when no handlers are provided', async () => {
+    injectClient();
+
+    await paymentKafkaService.subscribeToBookingEvents({});
+
+    expect(mockClient.subscribe).not.toHaveBeenCalled();
+  });
+
+  it('subscribes to VOYAGE_BOOKING_CREATED when onBookingCreated is provided', async () => {
+    injectClient();
+    const handler = jest.fn();
+
+    await paymentKafkaService.subscribeToBookingEvents({ onBookingCreated: handler });
+
+    expect(mockClient.subscribe).toHaveBeenCalledWith(
+      CONSUMER_GROUPS.PAYMENT_SERVICE,
+      [{ topic: KAFKA_TOPICS.VOYAGE_BOOKING_CREATED, handler }]
+    );
+  });
+
+  it('subscribes to VOYAGE_BOOKING_CANCELLED when onBookingCancelled is provided', async () => {
+    injectClient();
+    const handler = jest.fn();
+
+    await paymentKafkaService.subscribeToBookingEvents({ onBookingCancelled: handler });
+
+    expect(mockClient.subscribe).toHaveBeenCalledWith(
+      CONSUMER_GROUPS.PAYMENT_SERVICE,
+      [{ topic: KAFKA_TOPICS.VOYAGE_BOOKING_CANCELLED, handler }]
+    );
+  });
+
+  it('subscribes to both topics when both handlers are provided', async () => {
+    injectClient();
+    const onCreated = jest.fn();
+    const onCancelled = jest.fn();
+
+    await paymentKafkaService.subscribeToBookingEvents({
+      onBookingCreated: onCreated,
+      onBookingCancelled: onCancelled,
+    });
+
+    expect(mockClient.subscribe).toHaveBeenCalledWith(
+      CONSUMER_GROUPS.PAYMENT_SERVICE,
+      [
+        { topic: KAFKA_TOPICS.VOYAGE_BOOKING_CREATED, handler: onCreated },
+        { topic: KAFKA_TOPICS.VOYAGE_BOOKING_CANCELLED, handler: onCancelled },
+      ]
+    );
+  });
+});
+
+// ─── healthCheck() ────────────────────────────────────────────────────────────
+
+describe('healthCheck()', () => {
+  it('returns unhealthy status when client is not initialized', async () => {
+    const result = await paymentKafkaService.healthCheck();
+
+    expect(result).toEqual({
+      healthy: false,
+      details: { error: 'Client not initialized' },
+    });
+  });
+
+  it('delegates to client.healthCheck() when initialized', async () => {
+    injectClient();
+    mockClient.healthCheck.mockResolvedValueOnce({
+      healthy: true,
+      details: { connected: true, broker: 'localhost:9092' },
+    });
+
+    const result = await paymentKafkaService.healthCheck();
+
+    expect(mockClient.healthCheck).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ healthy: true, details: { connected: true, broker: 'localhost:9092' } });
+  });
+});


### PR DESCRIPTION
…-024

- Introduced jest.config.test024.js for unit testing specific to DR-538-US-TEST-024.
- Added comprehensive unit tests for DatabaseService and PaymentKafkaService, including initialization, shutdown, and event publishing methods.
- Mocked external dependencies to ensure isolated testing.
- Updated package.json with new test scripts for the added configuration.

This commit enhances test coverage for the payment processing functionalities and ensures robust error handling in the services.